### PR TITLE
Add track and position to playback-queue-ended

### DIFF
--- a/android/src/main/java/guichaguri/trackplayer/logic/MediaManager.java
+++ b/android/src/main/java/guichaguri/trackplayer/logic/MediaManager.java
@@ -212,10 +212,13 @@ public class MediaManager {
         }
     }
 
-    public void onEnd() {
+    public void onEnd(Track previous, long prevPos) {
         Log.d(Utils.TAG, "onEnd");
 
-        Events.dispatchEvent(service, Events.PLAYBACK_QUEUE_ENDED, null);
+        Bundle bundle = new Bundle();
+        bundle.putString("track", previous != null ? previous.id : null);
+        bundle.putDouble("position", Utils.toSeconds(prevPos));
+        Events.dispatchEvent(service, Events.PLAYBACK_QUEUE_ENDED, bundle);
     }
 
     public void onStateChange(int state) {

--- a/android/src/main/java/guichaguri/trackplayer/player/Playback.java
+++ b/android/src/main/java/guichaguri/trackplayer/player/Playback.java
@@ -231,4 +231,11 @@ public abstract class Playback {
 
         manager.onTrackUpdate(previous, position, next, true);
     }
+
+    protected void onEnd() {
+      Track previous = getCurrentTrack();
+      long position = getPosition();
+
+      manager.onEnd(previous, position);
+    }
 }

--- a/android/src/main/java/guichaguri/trackplayer/player/players/AndroidPlayback.java
+++ b/android/src/main/java/guichaguri/trackplayer/player/players/AndroidPlayback.java
@@ -240,7 +240,7 @@ public class AndroidPlayback extends Playback implements OnInfoListener, OnCompl
         if(hasNext()) {
             updateCurrentTrack(currentTrack + 1, null);
         } else {
-            manager.onEnd();
+            onEnd();
         }
     }
 

--- a/android/src/main/java/guichaguri/trackplayer/player/players/CastPlayback.java
+++ b/android/src/main/java/guichaguri/trackplayer/player/players/CastPlayback.java
@@ -339,7 +339,7 @@ public class CastPlayback extends Playback implements RemoteMediaClient.Listener
 
         if(state == PlaybackStateCompat.STATE_STOPPED) {
             if(lastKnownIdleReason == MediaStatus.IDLE_REASON_FINISHED) {
-                manager.onEnd();
+                onEnd();
             }
         }
     }

--- a/android/src/main/java/guichaguri/trackplayer/player/players/ExoPlayback.java
+++ b/android/src/main/java/guichaguri/trackplayer/player/players/ExoPlayback.java
@@ -210,7 +210,7 @@ public class ExoPlayback extends Playback implements EventListener {
             if(hasNext()) {
                 updateCurrentTrack(currentTrack + 1, null);
             } else {
-                manager.onEnd();
+                onEnd();
             }
 
         }

--- a/ios/RNTrackPlayer/Logic/MediaWrapper.swift
+++ b/ios/RNTrackPlayer/Logic/MediaWrapper.swift
@@ -12,7 +12,7 @@ import MediaPlayer
 protocol MediaWrapperDelegate: class {
     func playerUpdatedState()
     func playerSwitchedTracks(trackId: String?, time: TimeInterval?, nextTrackId: String?)
-    func playerExhaustedQueue()
+    func playerExhaustedQueue(trackId: String?, time: TimeInterval?)
     func playbackFailed(error: Error)
 }
 
@@ -198,9 +198,9 @@ class MediaWrapper: AudioPlayerDelegate {
         delegate?.playerSwitchedTracks(trackId: from?.id, time: position, nextTrackId: track.id)
     }
     
-    func audioPlayer(_ audioPlayer: AudioPlayer, didFinishPlaying item: Track) {
+    func audioPlayer(_ audioPlayer: AudioPlayer, didFinishPlaying item: Track, at position: TimeInterval?) {
         if (!playNext()) {
-            delegate?.playerExhaustedQueue()
+            delegate?.playerExhaustedQueue(trackId: item.id, time: position)
         }
     }
     

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -33,8 +33,11 @@ class RNTrackPlayer: RCTEventEmitter, MediaWrapperDelegate {
         ])
     }
     
-    func playerExhaustedQueue() {
-        sendEvent(withName: "playback-queue-ended", body: nil)
+    func playerExhaustedQueue(trackId: String?, time: TimeInterval?) {
+      sendEvent(withName: "playback-queue-ended", body: [
+          "track": trackId,
+          "position": time,
+      ])
     }
     
     func playbackFailed(error: Error) {

--- a/ios/RNTrackPlayer/Vendor/AudioPlayer/player/AudioPlayerDelegate.swift
+++ b/ios/RNTrackPlayer/Vendor/AudioPlayer/player/AudioPlayerDelegate.swift
@@ -37,7 +37,7 @@ protocol AudioPlayerDelegate: class {
     /// - Parameters:
     ///   - audioPlayer: The audio player.
     ///   - item: The item that it just finished playing.
-    func audioPlayer(_ audioPlayer: AudioPlayer, didFinishPlaying item: Track)
+    func audioPlayer(_ audioPlayer: AudioPlayer, didFinishPlaying item: Track, at position: TimeInterval?)
 
     /// This method is called a regular time interval while playing. It notifies the delegate that the current playing
     /// progression changed.

--- a/ios/RNTrackPlayer/Vendor/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
+++ b/ios/RNTrackPlayer/Vendor/AudioPlayer/player/extensions/AudioPlayer+PlayerEvent.swift
@@ -19,7 +19,7 @@ extension AudioPlayer {
                 state = .failed(.foundationError(error))
             } else {
                 if let currentItem = currentItem {
-                    delegate?.audioPlayer(self, didFinishPlaying: currentItem)
+                    delegate?.audioPlayer(self, didFinishPlaying: currentItem, at: currentItemProgression)
                 }
             }
 

--- a/windows/RNTrackPlayer/Logic/MediaManager.cs
+++ b/windows/RNTrackPlayer/Logic/MediaManager.cs
@@ -42,10 +42,13 @@ namespace TrackPlayer.Logic {
             return player;
         }
 
-        public void OnEnd() {
+        public void OnEnd(Track previous, double prevPos) {
             Debug.WriteLine("OnEnd");
 
-            SendEvent(Events.PlaybackQueueEnded, null);
+            JObject obj = new JObject();
+            obj.Add("track", previous?.id);
+            obj.Add("position", prevPos);
+            SendEvent(Events.PlaybackQueueEnded, obj);
         }
 
         public void OnStateChange(MediaPlaybackState state) {

--- a/windows/RNTrackPlayer/Players/LocalPlayback.cs
+++ b/windows/RNTrackPlayer/Players/LocalPlayback.cs
@@ -128,7 +128,7 @@ namespace TrackPlayer.Players {
                 UpdateCurrentTrack(currentTrack + 1, null);
                 Play();
             } else {
-                manager.OnEnd();
+                HandleOnEnd();
             }
         }
 

--- a/windows/RNTrackPlayer/Players/Playback.cs
+++ b/windows/RNTrackPlayer/Players/Playback.cs
@@ -61,6 +61,13 @@ namespace TrackPlayer.Players {
             manager.OnTrackUpdate(previous, position, track, true);
         }
 
+        protected void HandleOnEnd() {
+            Track previous = GetCurrentTrack();
+            double position = GetPosition();
+
+            manager.OnEnd(previous, position);
+        }
+
         public Track GetCurrentTrack() {
             return currentTrack >= 0 && currentTrack < queue.Count ? queue[currentTrack] : null;
         }


### PR DESCRIPTION
As my use case requires a double check of the actual position when a track ends, I need a way to get the position for the last track playing on a queue. This is currently not possible (at least on iOS).

When the last track ends, only `playback-queue-ended` is fired, and not `playback-track-changed` which otherwise contains the needed information.

I would love to work on a solution for this and submit a PR, but would like to get confirmation on API before I implement it.

The easy fix, would be to add `track` and `position` to `playback-queue-ended`. I've started this work here (and it seems to work just fine).

Let me know if you want me to continue down this road.

- [x] iOS
- [x] Android
- [x] Windows
- [ ] Update wiki