### PR TITLE
[iOS] Use pause when queue is exhausted

### DIFF
--- a/ios/RNTrackPlayer/Logic/MediaWrapper.swift
+++ b/ios/RNTrackPlayer/Logic/MediaWrapper.swift
@@ -135,7 +135,7 @@ class MediaWrapper: AudioPlayerDelegate {
             return true
         }
         
-        stop()
+        pause()
         return false
     }
     


### PR DESCRIPTION
When using `stop()` you wont be able to poll the player for the position it ended at when queue is exhausted.

Currently `TrackPlayer.getPosition()` resolves with `0` when the queue is exhausted.

I would expect it to resolve with the position the player had, when the queue was exhausted.

Another side effect for this, would be that the app and the track stays in the Control Center and on the lock screen. When calling `stop()` they are removed from those places.