### PR TITLE
[Android] Keep js context after unbind

### DIFF
--- a/android/src/main/java/guichaguri/trackplayer/logic/Events.java
+++ b/android/src/main/java/guichaguri/trackplayer/logic/Events.java
@@ -28,6 +28,7 @@ public class Events {
     public static final String PLAYBACK_TRACK_CHANGED = "playback-track-changed";
     public static final String PLAYBACK_QUEUE_ENDED = "playback-queue-ended";
     public static final String PLAYBACK_ERROR = "playback-error";
+    public static final String PLAYBACK_UNBIND = "playback-unbind";
 
     public static void dispatchEvent(Context context, String event, Bundle data) {
         Intent i = new Intent(context, PlayerTask.class);

--- a/android/src/main/java/guichaguri/trackplayer/logic/MediaManager.java
+++ b/android/src/main/java/guichaguri/trackplayer/logic/MediaManager.java
@@ -265,6 +265,11 @@ public class MediaManager {
         }
     }
 
+    public void onServiceUnbounded() {
+        Bundle bundle = new Bundle();
+        Events.dispatchEvent(service, Events.PLAYBACK_UNBIND, bundle);
+    }
+    
     public void onServiceDestroy() {
         Log.i(Utils.TAG, "Destroying resources");
 

--- a/android/src/main/java/guichaguri/trackplayer/logic/services/PlayerService.java
+++ b/android/src/main/java/guichaguri/trackplayer/logic/services/PlayerService.java
@@ -36,6 +36,14 @@ public class PlayerService extends MediaBrowserServiceCompat {
         }
     }
 
+    @Override
+    public boolean onUnbind(Intent intent) {
+        Log.d(Utils.TAG, "onUnbind");
+        super.onUnbind(intent);
+        manager.onServiceUnbounded();
+        return true;
+    }
+
     @Nullable
     @Override
     public BrowserRoot onGetRoot(@NonNull String clientPackageName, int clientUid, @Nullable Bundle rootHints) {


### PR DESCRIPTION
Give an ability for js context to restart and keep working (as headless task) after unbind. This is useful when project needs some logic like sleep timer or analytics. Also its useful to keep track on current progress to restore later. And it will also helps to keep notification responsive when use controls if app is closed.

Its worth noting that timers is needed (setTimeout/setInterval) in Headless task its possible to return promise on `playback-unbind` event from js and keep it (do not resolve) until app become active again.

Not really sure about constant naming as its not really related to playback.
Would love to hear some feedback.