### PR TITLE
Fix #105 where onTaskRemoved was no longer being called

### DIFF
--- a/android/src/main/java/guichaguri/trackplayer/TrackModule.java
+++ b/android/src/main/java/guichaguri/trackplayer/TrackModule.java
@@ -83,8 +83,9 @@ public class TrackModule extends ReactContextBaseJavaModule implements ServiceCo
 
         // Binds the service to get a MediaWrapper instance
         Intent intent = new Intent(context, PlayerService.class);
+        context.startService(intent);
         intent.setAction(PlayerService.ACTION_CONNECT);
-        context.bindService(intent, this, Service.BIND_AUTO_CREATE);
+        context.bindService(intent, this, 0);
 
         connecting = true;
     }


### PR DESCRIPTION
See more on the difference between passing `0` and `BIND_AUTO_CREATE` to `bindService` : https://stackoverflow.com/questions/14746245/use-0-or-bind-auto-create-for-bindservices-flag

Seeing as `Context.BIND_AUTO_CREATE` starts the service for us automatically, we need to do it manually by calling `context.startService(intent);`