### PR TITLE
Fix incorrect capability type and implement requiresMainQueueSetup

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -84,7 +84,7 @@ class RNTrackPlayer: RCTEventEmitter, MediaWrapperDelegate {
             "remote-play",
             "remote-next",
             "remote-previous",
-            "remote-jump-foward",
+            "remote-jump-forward",
             "remote-jump-backward",
         ]
     }
@@ -120,8 +120,8 @@ class RNTrackPlayer: RCTEventEmitter, MediaWrapperDelegate {
         let enablePlay = capabilities.contains(.play)
         let enablePlayNext = capabilities.contains(.next)
         let enablePlayPrevious = capabilities.contains(.previous)
-        let enableSkipForward = capabilities.contains(.skipForward)
-        let enableSkipBackward = capabilities.contains(.skipBackward)
+        let enableSkipForward = capabilities.contains(.jumpForward)
+        let enableSkipBackward = capabilities.contains(.jumpBackward)
         
         toggleRemoteHandler(command: remoteCenter.stopCommand, selector: #selector(remoteSentStop), enabled: enableStop)
         toggleRemoteHandler(command: remoteCenter.pauseCommand, selector: #selector(remoteSentPause), enabled: enablePause)

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -47,8 +47,7 @@ class RNTrackPlayer: RCTEventEmitter, MediaWrapperDelegate {
     
     // MARK: - Required Methods
     
-    @objc(requiresMainQueueSetup)
-    override func requiresMainQueueSetup() -> Bool {
+    override open static func requiresMainQueueSetup() -> Bool {
         return true;
     }
     


### PR DESCRIPTION
This should fix https://github.com/react-native-kit/react-native-track-player/issues/109 and https://github.com/react-native-kit/react-native-track-player/issues/126.

Fix for 126 is based on https://github.com/wuxudong/react-native-charts-wrapper/blob/master/ios/ReactNativeCharts/pie/RNPieChartManager.swift#L14-L16. I am not familiar with swift so not sure if this is correct. But the library compiles for me and I am able to play tracks.