### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ios",
     "windows"
   ],
-  "license": "GPL-3.0",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-kit/react-native-track-player.git"


### PR DESCRIPTION
In 05b6bfe the license was changed from GPL-3.0 to Apache-2.0. The license field in package.json should be updated to reflect this.