### PR TITLE
Allow setting rate while buffering in ios

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -266,7 +266,7 @@ class RNTrackPlayer: RCTEventEmitter, MediaWrapperDelegate {
     
     @objc(setRate:)
     func setRate(rate: Float) {
-        guard [.playing].contains(mediaWrapper.mappedState) else { return }
+        guard [.buffering, .playing].contains(mediaWrapper.mappedState) else { return }
         print("Setting rate to \(rate)")
         mediaWrapper.rate = rate
     }


### PR DESCRIPTION
Currently trying to set rate right after calling play is a noop if track is being buffered and has not started playing yet, this pr fixes that, so code like that would work correctly:
```
await TrackPlayer.play()
TrackPlayer.setRate(someRate)
```