### PR TITLE
Handle Capabilities correctly on iOS

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -129,16 +129,22 @@ class RNTrackPlayer: RCTEventEmitter, MediaWrapperDelegate {
     @objc(updateOptions:)
     func update(options: [String: Any]) {
         let remoteCenter = MPRemoteCommandCenter.shared()
-        let castedCapabilities = (options["capabilities"] as? [String])
-        let capabilities = castedCapabilities?.flatMap { Capability(rawValue: $0) } ?? []
+        let rawCapabilites = options["capabilities"]
+        var capabilities = [String]()
         
-        let enableStop = capabilities.contains(.stop)
-        let enablePause = capabilities.contains(.pause)
-        let enablePlay = capabilities.contains(.play)
-        let enablePlayNext = capabilities.contains(.next)
-        let enablePlayPrevious = capabilities.contains(.previous)
-        let enableSkipForward = capabilities.contains(.jumpForward)
-        let enableSkipBackward = capabilities.contains(.jumpBackward)
+        if (rawCapabilites != nil)
+        {
+            let castedCapabilities = rawCapabilites as! [Any]
+            capabilities = castedCapabilities.flatMap { $0 as? String }
+        }
+        
+        let enableStop = capabilities.contains("stop")
+        let enablePause = capabilities.contains("pause")
+        let enablePlay = capabilities.contains("play")
+        let enablePlayNext = capabilities.contains("next")
+        let enablePlayPrevious = capabilities.contains("previous")
+        let enableSkipForward = capabilities.contains("jumpForward")
+        let enableSkipBackward = capabilities.contains("jumpBackward")
         
         toggleRemoteHandler(command: remoteCenter.stopCommand, selector: #selector(remoteSentStop), enabled: enableStop)
         toggleRemoteHandler(command: remoteCenter.pauseCommand, selector: #selector(remoteSentPause), enabled: enablePause)


### PR DESCRIPTION
A permanent fix for #77.

Based on the solution @brenwell provided this correctly casts the `capabilities` option to enable the lock screen control center media controls. 

Works in all the following scenario:

#### No capabilities or Empty capabilities provided
```
TrackPlayer.updateOptions({
});

// OR

TrackPlayer.updateOptions({
  capabilities: []
});
```
<img width="392" alt="screen shot 2018-10-08 at 1 13 14 pm" src="https://user-images.githubusercontent.com/5445860/46631350-fb81f400-cafb-11e8-8a6c-dccb40ea9e54.png">

#### Partial array of capabilities provided
```
TrackPlayer.updateOptions({
  capabilities: [
    TrackPlayer.CAPABILITY_SKIP_TO_NEXT,
    TrackPlayer.CAPABILITY_SKIP_TO_PREVIOUS,
    TrackPlayer.CAPABILITY_SEEK_TO,
  ]
});

// OR

TrackPlayer.updateOptions({
  capabilities: [
    TrackPlayer.CAPABILITY_PLAY,
    TrackPlayer.CAPABILITY_PAUSE,
  ]
});

// OR

TrackPlayer.updateOptions({
  capabilities: [
    TrackPlayer.CAPABILITY_PLAY,
    TrackPlayer.CAPABILITY_PAUSE,
    TrackPlayer.CAPABILITY_SKIP_TO_NEXT,
    TrackPlayer.CAPABILITY_SKIP_TO_PREVIOUS,
    TrackPlayer.CAPABILITY_SEEK_TO,
  ]
});
```
![image](https://user-images.githubusercontent.com/5445860/46631599-bdd19b00-cafc-11e8-8f15-cfb951895030.png)

![image](https://user-images.githubusercontent.com/5445860/46631607-c0cc8b80-cafc-11e8-8e44-c68113708253.png)

![image](https://user-images.githubusercontent.com/5445860/46631575-b01c1580-cafc-11e8-8d01-d49d1e0d1b11.png)


I'm not familiar with swift syntax so I'm not sure if this method of casting is correct or acceptable for this repo. However I do know the current way is not working as documented and this seems to provide a complete fix.

As always thanks for maintaining this repo.
Cheers!
