### PR TITLE
[android] adding Ongoing to updateOptions

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -131,6 +131,11 @@ public class MetadataManager {
                 for(int cap : compact) compactActions |= cap;
             }
         }
+        
+        // make the notification ongoing
+        if(options.getBoolean("onGoing") == true){
+            builder.setOngoing(true);
+        }
 
         // Update the color
         builder.setColor(options.getInt("color", NotificationCompat.COLOR_DEFAULT));


### PR DESCRIPTION
adding the option to make the notification onGoing, this should introduce a workaround for https://github.com/react-native-kit/react-native-track-player/issues/317 and https://github.com/react-native-kit/react-native-track-player/issues/307

```javascript
    TrackPlayer.updateOptions({
      onGoing: true,
    });
```