### PR TITLE
Cache queue to allow resume after service is killed

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -4,6 +4,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.support.v4.content.LocalBroadcastManager;
@@ -97,7 +98,16 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
 
         // Binds the service to get a MediaWrapper instance
         Intent intent = new Intent(context, MusicService.class);
-        context.startService(intent);
+        try {
+            context.startService(intent);
+        } catch (Exception e) {
+            if (Build.VERSION.SDK_INT >= 26) {
+                context.startForegroundService(intent);
+            } else {
+                context.startService(intent);
+            }
+        }
+
         intent.setAction(Utils.CONNECT_INTENT);
         context.bindService(intent, this, 0);
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -285,7 +285,7 @@ public class MusicManager implements OnAudioFocusChangeListener {
         }
     }
 
-    public void destroy() {
+    public void destroy(Boolean intentToStop) {
         Log.d(Utils.LOG, "Releasing service resources...");
 
         // Disable audio focus
@@ -295,7 +295,7 @@ public class MusicManager implements OnAudioFocusChangeListener {
         if(playback != null) playback.destroy();
 
         // Release the metadata resources
-        metadata.destroy();
+        metadata.destroy(intentToStop);
 
         // Release the locks
         if(wifiLock.isHeld()) wifiLock.release();

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -95,6 +95,7 @@ public class MusicService extends HeadlessJsTaskService {
     }
 
     private void recoverLostPlayer() {
+
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
 
         Integer resumeAt = 0;
@@ -103,6 +104,8 @@ public class MusicService extends HeadlessJsTaskService {
         String cachedCurrentTrack = prefs.getString("cachedCurrentTrack", null);
         Track currentTrack = new Track(getApplicationContext(), jsonStringToBundle(cachedCurrentTrack), RatingCompat.RATING_NONE); // Temp rating none, because we use none;
 
+        // Get current track position
+        Long currentPosition = prefs.getLong("cachedPosition", 0);
 
         // Get cached queue
         Set<String> cachedQueueSet = prefs.getStringSet("cachedQueue", null);
@@ -126,8 +129,8 @@ public class MusicService extends HeadlessJsTaskService {
             manager.switchPlayback(playback);
         }
 
-
         playback.add(cachedQueue, resumeAt, null);
+        playback.seekTo(currentPosition);
         playback.play();
 
         // Get back player options
@@ -147,10 +150,12 @@ public class MusicService extends HeadlessJsTaskService {
             // Cache current track
             Track currentTrack = playback.getCurrentTrack();
             editor.putString("cachedCurrentTrack", currentTrack.json.toString());
-            // TODO GET POSITION
+
+            // Cache current track position
+            Long currentPosition = playback.getPosition();
+            editor.putLong("cachedPosition", currentPosition);
 
             // Cache queue
-            Log.d(Utils.LOG, "Caching queue");
             Set<String> set = new HashSet<>();
             List<Track> tracks = playback.getQueue();
             for(Track track : tracks) {
@@ -159,7 +164,6 @@ public class MusicService extends HeadlessJsTaskService {
             editor.putStringSet("cachedQueue", set);
 
             // Cache options
-            Log.d(Utils.LOG, "Caching options");
             Bundle options = manager.getMetadata().getOptionsBundle();
             editor.putString("cachedOptions", bundleToJson(options).toString());
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -74,7 +74,6 @@ public class MusicService extends HeadlessJsTaskService {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        Log.d(Utils.LOG, "Intent action is " + intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT));
 
         if (intent != null && Intent.ACTION_MEDIA_BUTTON.equals(intent.getAction())) {
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -1,14 +1,33 @@
 package com.guichaguri.trackplayer.service;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.preference.PreferenceManager;
 import android.support.v4.content.LocalBroadcastManager;
+import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaButtonReceiver;
+import android.util.Log;
 
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+import com.guichaguri.trackplayer.service.models.Track;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+
 import javax.annotation.Nullable;
 
 /**
@@ -51,7 +70,19 @@ public class MusicService extends HeadlessJsTaskService {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         if (intent != null && Intent.ACTION_MEDIA_BUTTON.equals(intent.getAction())) {
-            MediaButtonReceiver.handleIntent(manager.getMetadata().getSession(), intent);
+            try {
+                MediaButtonReceiver.handleIntent(manager.getMetadata().getSession(), intent);
+            } catch (NullPointerException e) {
+                Log.d(Utils.LOG, "MusicService trying to handle intent with manager that does not exist");
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+                Set<String> cachedQueueSet = prefs.getStringSet("cachedQueue", null);
+                List<Track> cachedQueue = Collections.emptyList();
+                for (String s : cachedQueueSet) {
+                    Bundle trackBundle = jsonStringToBundle(s);
+                    Track track = new Track(getApplicationContext(), trackBundle, RatingCompat.RATING_NONE); // Temp rating none;
+                    cachedQueue.add(track);
+                }
+            }
             return START_NOT_STICKY;
         }
 
@@ -60,11 +91,48 @@ public class MusicService extends HeadlessJsTaskService {
         return START_STICKY;
     }
 
+    public static Bundle jsonStringToBundle(String jsonString){
+        try {
+            JSONObject jsonObject = toJsonObject(jsonString);
+            return jsonToBundle(jsonObject);
+        } catch (JSONException ignored) {
+
+        }
+        return null;
+    }
+    public static JSONObject toJsonObject(String jsonString) throws JSONException {
+        return new JSONObject(jsonString);
+    }
+    public static Bundle jsonToBundle(JSONObject jsonObject) throws JSONException {
+        Bundle bundle = new Bundle();
+        Iterator iter = jsonObject.keys();
+        while(iter.hasNext()){
+            String key = (String)iter.next();
+            String value = jsonObject.getString(key);
+            bundle.putString(key,value);
+        }
+        return bundle;
+    }
+
     @Override
     public void onDestroy() {
         super.onDestroy();
 
         if (manager != null) {
+
+            Set<String> set = new HashSet<>();
+
+            List<Track> tracks = manager.getPlayback().getQueue();
+
+            for(Track track : tracks) {
+                set.add(track.json.toString());
+            }
+
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+            SharedPreferences.Editor editor = prefs.edit();
+            editor.putStringSet("cachedQueue", set);
+            editor.apply();
+
             manager.destroy();
             manager = null;
         }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -203,6 +203,7 @@ public class MusicService extends HeadlessJsTaskService {
 
             // Cache current track
             Track currentTrack = playback.getCurrentTrack();
+            if (currentTrack == null) return;
             editor.putString("cachedCurrentTrack", currentTrack.json.toString());
 
             // Cache current track position

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -85,7 +85,7 @@ public class MusicService extends HeadlessJsTaskService {
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
                 String cachedCurrentTrack = prefs.getString("cachedCurrentTrack", null);
                 if (cachedCurrentTrack != null) {
-                    manager = new MusicManager(this, getApplicationContext());
+                    manager = new MusicManager(this);
                     recoverLostPlayer(intent);
                     return START_NOT_STICKY;
                 }
@@ -93,7 +93,7 @@ public class MusicService extends HeadlessJsTaskService {
         }
 
         if (manager == null) {
-            manager = new MusicManager(this, getApplicationContext());
+            manager = new MusicManager(this);
         }
 
         super.onStartCommand(intent, flags, startId);

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -206,6 +206,7 @@ public class MusicService extends HeadlessJsTaskService {
     private void cachePlayer(MusicManager manager) {
         if (manager != null) {
             ExoPlayback playback = manager.getPlayback();
+            if (playback == null) return;
 
             // Make editor
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
@@ -257,13 +258,14 @@ public class MusicService extends HeadlessJsTaskService {
 
     @Override
     public void onDestroy() {
-
         super.onDestroy();
-        if (!intentToStop && manager != null) {
-           cachePlayer(manager);
+        if (manager != null) {
+            if (!intentToStop) {
+               cachePlayer(manager);
+            }
+            manager.destroy(intentToStop);
+            manager = null;
         }
-        manager.destroy(intentToStop);
-        manager = null;
     }
 
     @Override

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -164,6 +164,7 @@ public class MusicService extends HeadlessJsTaskService {
         ButtonEvents buttonEvents = new ButtonEvents(this, manager);
         if (intentExtra.getKeyCode() == KEYCODE_MEDIA_PLAY || intentExtra.getKeyCode() == KEYCODE_HEADSETHOOK) {
             playback.seekTo(currentPosition);
+            manager.getMetadata().updateMetadata(currentTrack);
             buttonEvents.onPlay();
         } else if (intentExtra.getKeyCode() == KEYCODE_MEDIA_NEXT) {
             this.emit(MusicEvents.BUTTON_SKIP_NEXT, null);

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -42,6 +42,7 @@ import static com.guichaguri.trackplayer.service.Utils.bundleToJson;
 public class MusicService extends HeadlessJsTaskService {
 
     private MusicManager manager;
+    private Boolean intentToStop = false;
 
     @Nullable
     @Override
@@ -77,9 +78,14 @@ public class MusicService extends HeadlessJsTaskService {
     public int onStartCommand(Intent intent, int flags, int startId) {
 
         if (intent != null && Intent.ACTION_MEDIA_BUTTON.equals(intent.getAction())) {
+
             // Interpret event
             KeyEvent intentExtra = intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
-            Log.d(Utils.LOG, "keyCode " + intentExtra.getKeyCode());
+            if (intentExtra.getKeyCode() == KEYCODE_MEDIA_STOP) {
+                intentToStop = true;
+            } else {
+                intentToStop = false;
+            }
 
             if (manager != null && manager.getMetadata().getSession() != null) {
                 MediaButtonReceiver.handleIntent(manager.getMetadata().getSession(), intent);
@@ -223,8 +229,10 @@ public class MusicService extends HeadlessJsTaskService {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        cachePlayer(manager);
-        manager.destroy();
+        if (!intentToStop) {
+            cachePlayer(manager);
+        }
+        manager.destroy(intentToStop);
         manager = null;
     }
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -9,24 +9,29 @@ import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaButtonReceiver;
 import android.util.Log;
+import android.view.KeyEvent;
 
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.Promise;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+import com.guichaguri.trackplayer.module.MusicEvents;
+import com.guichaguri.trackplayer.service.metadata.ButtonEvents;
 import com.guichaguri.trackplayer.service.models.Track;
 import com.guichaguri.trackplayer.service.player.ExoPlayback;
 
-import org.json.JSONObject;
-
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import static android.view.KeyEvent.KEYCODE_HEADSETHOOK;
+import static android.view.KeyEvent.KEYCODE_MEDIA_FAST_FORWARD;
+import static android.view.KeyEvent.KEYCODE_MEDIA_NEXT;
+import static android.view.KeyEvent.KEYCODE_MEDIA_PLAY;
+import static android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS;
+import static android.view.KeyEvent.KEYCODE_MEDIA_REWIND;
 import static com.guichaguri.trackplayer.service.Utils.jsonStringToBundle;
 import static com.guichaguri.trackplayer.service.Utils.bundleToJson;
 
@@ -69,21 +74,22 @@ public class MusicService extends HeadlessJsTaskService {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        Log.d(Utils.LOG, "Intent action is " + intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT));
 
         if (intent != null && Intent.ACTION_MEDIA_BUTTON.equals(intent.getAction())) {
 
             if (manager != null && manager.getMetadata().getSession() != null) {
-                Log.d(Utils.LOG, "Manager not null and session returned");
                 MediaButtonReceiver.handleIntent(manager.getMetadata().getSession(), intent);
                 return START_NOT_STICKY;
-            } else if (manager != null) {
-                Log.d(Utils.LOG, "MusicService trying to recover lost player");
-            } else {
-                Log.d(Utils.LOG, "Manager null");
-                manager = new MusicManager(this, getApplicationContext());
-                recoverLostPlayer();
+            } else if (manager == null) {
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+                String cachedCurrentTrack = prefs.getString("cachedCurrentTrack", null);
+                if (cachedCurrentTrack != null) {
+                    manager = new MusicManager(this, getApplicationContext());
+                    recoverLostPlayer(intent);
+                    return START_NOT_STICKY;
+                }
             }
-
         }
 
         if (manager == null) {
@@ -94,18 +100,23 @@ public class MusicService extends HeadlessJsTaskService {
         return START_STICKY;
     }
 
-    private void recoverLostPlayer() {
+    private void recoverLostPlayer(Intent intent) {
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
 
-        Integer resumeAt = 0;
-
-        // Get current track
+        // Get current track and return if it is not available
         String cachedCurrentTrack = prefs.getString("cachedCurrentTrack", null);
-        Track currentTrack = new Track(getApplicationContext(), jsonStringToBundle(cachedCurrentTrack), RatingCompat.RATING_NONE); // Temp rating none, because we use none;
+        if (cachedCurrentTrack == null) return;
+
+        // Get back player options
+        String cachedOptionsJsonString = prefs.getString("cachedOptions", null);
+        Bundle optionsBundle = jsonStringToBundle(cachedOptionsJsonString);
 
         // Get current track position
+        Integer ratingType = optionsBundle.getInt("ratingType", RatingCompat.RATING_NONE);
+        Track currentTrack = new Track(getApplicationContext(), jsonStringToBundle(cachedCurrentTrack), ratingType);
         Long currentPosition = prefs.getLong("cachedPosition", 0);
+        Integer resumeAt = 0;
 
         // Get cached queue
         Set<String> cachedQueueSet = prefs.getStringSet("cachedQueue", null);
@@ -113,14 +124,13 @@ public class MusicService extends HeadlessJsTaskService {
         Integer index = 0;
         for (String s : cachedQueueSet) {
             Bundle trackBundle = jsonStringToBundle(s);
-            Track track = new Track(getApplicationContext(), trackBundle, RatingCompat.RATING_NONE); // Temp rating none, because we use none;
+            Track track = new Track(getApplicationContext(), trackBundle, ratingType);
             if (track.id.equals(currentTrack.id)) {
                 resumeAt = index;
             }
             cachedQueue.add(track);
             index ++;
         }
-
 
         // Reestablish manager
         ExoPlayback playback = manager.getPlayback();
@@ -130,13 +140,36 @@ public class MusicService extends HeadlessJsTaskService {
         }
 
         playback.add(cachedQueue, resumeAt, null);
-        playback.seekTo(currentPosition);
-        playback.play();
 
-        // Get back player options
-        String cachedOptionsJsonString = prefs.getString("cachedOptions", null);
-        Bundle optionsBundle = jsonStringToBundle(cachedOptionsJsonString);
+        // Set player options
         manager.getMetadata().updateOptions(optionsBundle);
+
+        // Interpret event
+        KeyEvent intentExtra = intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
+        ButtonEvents buttonEvents = new ButtonEvents(this, manager);
+        if (intentExtra.getKeyCode() == KEYCODE_MEDIA_PLAY || intentExtra.getKeyCode() == KEYCODE_HEADSETHOOK) {
+            playback.seekTo(currentPosition);
+            buttonEvents.onPlay();
+        } else if (intentExtra.getKeyCode() == KEYCODE_MEDIA_NEXT) {
+            this.emit(MusicEvents.BUTTON_SKIP_NEXT, null);
+            buttonEvents.onSkipToNext();
+        } else if (intentExtra.getKeyCode() == KEYCODE_MEDIA_FAST_FORWARD) {
+            buttonEvents.onFastForward();
+        } else if (intentExtra.getKeyCode() == KEYCODE_MEDIA_REWIND) {
+            buttonEvents.onRewind();
+        } else if (intentExtra.getKeyCode() == KEYCODE_MEDIA_PREVIOUS) {
+            buttonEvents.onSkipToPrevious();
+        } else {
+            Log.d(Utils.LOG, "keyCode " + intentExtra.getKeyCode() + " is not handled");
+        }
+
+        // Clear cache
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.remove("cachedCurrentTrack");
+        editor.remove("cachedPosition");
+        editor.remove("cachedQueue");
+        editor.remove("cachedOptions");
+        editor.apply();
     }
 
     private void cachePlayer(MusicManager manager) {

--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -19,10 +19,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
 import java.util.Set;
 
 /**
@@ -175,9 +172,8 @@ public class Utils {
         Iterator iter = jsonObject.keys();
         while(iter.hasNext()) {
             String key = (String)iter.next();
-            Object keyObject = jsonObject.get(key);
             if (key.equals("capabilities") || key.equals("compactCapabilities")) {
-                // this check should be more generic but is functional for now. Decoding should probably live where data is instead.
+                // this check should be more generic but is functional for now.
                 ArrayList<Integer> value = new ArrayList<Integer>();
                 JSONArray jsonArray = jsonObject.getJSONArray(key);
                 int len = jsonArray.length();
@@ -193,12 +189,5 @@ public class Utils {
         }
         return bundle;
     }
-
-    public static void saveStringToSharedPreferences(String identifier, String data, Context context) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putString("cachedQueue", data);
-        editor.apply();
-    }
-
+    
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -14,10 +14,15 @@ import android.util.Log;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Set;
 
 /**
@@ -168,10 +173,23 @@ public class Utils {
     private static Bundle jsonToBundle(JSONObject jsonObject) throws JSONException {
         Bundle bundle = new Bundle();
         Iterator iter = jsonObject.keys();
-        while(iter.hasNext()){
+        while(iter.hasNext()) {
             String key = (String)iter.next();
-            String value = jsonObject.getString(key);
-            bundle.putString(key,value);
+            Object keyObject = jsonObject.get(key);
+            if (key.equals("capabilities") || key.equals("compactCapabilities")) {
+                // this check should be more generic but is functional for now. Decoding should probably live where data is instead.
+                ArrayList<Integer> value = new ArrayList<Integer>();
+                JSONArray jsonArray = jsonObject.getJSONArray(key);
+                int len = jsonArray.length();
+                for (int i=0;i<len;i++){
+                    value.add(jsonArray.getInt(i));
+                }
+                bundle.putIntegerArrayList(key,value);
+            } else {
+                String value = jsonObject.getString(key);
+                bundle.putString(key,value);
+            }
+
         }
         return bundle;
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -181,11 +181,14 @@ public class Utils {
                     value.add(jsonArray.getInt(i));
                 }
                 bundle.putIntegerArrayList(key,value);
+            } else if (key.equals("duration")) {
+                // this check should be in Track
+                Double value = jsonObject.getDouble(key);
+                bundle.putDouble(key, value);
             } else {
                 String value = jsonObject.getString(key);
                 bundle.putString(key,value);
             }
-
         }
         return bundle;
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -2,13 +2,23 @@ package com.guichaguri.trackplayer.service;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
+import android.util.Log;
+
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+import java.util.Set;
 
 /**
  * @author Guichaguri
@@ -125,6 +135,52 @@ public class Utils {
         } else {
             data.putDouble(key, rating.getStarRating());
         }
+    }
+
+    public static JSONObject bundleToJson(Bundle bundle) {
+        JSONObject json = new JSONObject();
+        Set<String> keys = bundle.keySet();
+        for (String key : keys) {
+            try {
+                // json.put(key, bundle.get(key)); see edit below
+                json.put(key, JSONObject.wrap(bundle.get(key)));
+            } catch(JSONException e) {
+                //Handle exception here
+                Log.d(Utils.LOG, "bundleToJson: Something went wrong, creating json");
+            }
+        }
+
+        return json;
+    }
+
+    public static Bundle jsonStringToBundle(String jsonString){
+        try {
+            JSONObject jsonObject = toJsonObject(jsonString);
+            return jsonToBundle(jsonObject);
+        } catch (JSONException ignored) {
+
+        }
+        return null;
+    }
+    private static JSONObject toJsonObject(String jsonString) throws JSONException {
+        return new JSONObject(jsonString);
+    }
+    private static Bundle jsonToBundle(JSONObject jsonObject) throws JSONException {
+        Bundle bundle = new Bundle();
+        Iterator iter = jsonObject.keys();
+        while(iter.hasNext()){
+            String key = (String)iter.next();
+            String value = jsonObject.getString(key);
+            bundle.putString(key,value);
+        }
+        return bundle;
+    }
+
+    public static void saveStringToSharedPreferences(String identifier, String data, Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putString("cachedQueue", data);
+        editor.apply();
     }
 
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -293,25 +293,27 @@ public class MetadataManager {
         }
     }
 
-    public void destroy() {
-        Log.d(Utils.LOG, "Destroy!");
+    public void destroy(Boolean intentToStop) {
 
         if(foreground) {
             NotificationManagerCompat.from(service).cancel(1);
         } else {
-            service.stopForeground(true);
+            service.stopForeground(false);
         }
 
-        session.setActive(false);
-        session.release();
-
+        if (!intentToStop) {
+            Notification n = builder.build();
+            NotificationManagerCompat.from(service).notify(1, n);
+        } else {
+            session.setActive(false);
+            session.release();
+        }
 
     }
 
     private void updateNotification() {
         int state = manager.getPlayback().getState();
         if (Utils.isStopped(state)) {
-            Log.d(Utils.LOG, "updateNotification: isStopped");
             removeNotifications();
             return;
         }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -36,9 +36,6 @@ import com.guichaguri.trackplayer.service.player.ExoPlayback;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.guichaguri.trackplayer.service.Utils.bundleToJson;
-import static com.guichaguri.trackplayer.service.Utils.saveStringToSharedPreferences;
-
 /**
  * @author Guichaguri
  */
@@ -47,7 +44,6 @@ public class MetadataManager {
     private final MusicService service;
     private final MusicManager manager;
     private final MediaSessionCompat session;
-    private Context applicationContext;
 
     private boolean foreground = false;
     private int ratingType = RatingCompat.RATING_NONE;
@@ -60,10 +56,9 @@ public class MetadataManager {
 
     private Action previousAction, rewindAction, playAction, pauseAction, stopAction, forwardAction, nextAction;
 
-    public MetadataManager(MusicService service, MusicManager manager, Context applicationContext) {
+    public MetadataManager(MusicService service, MusicManager manager) {
         this.service = service;
         this.manager = manager;
-        this.applicationContext = applicationContext;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel channel = new NotificationChannel(Utils.NOTIFICATION_CHANNEL, "Playback", NotificationManager.IMPORTANCE_DEFAULT);

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -302,8 +302,7 @@ public class MetadataManager {
         }
 
         if (!intentToStop) {
-            Notification n = builder.build();
-            NotificationManagerCompat.from(service).notify(1, n);
+            updateNotification();
         } else {
             session.setActive(false);
             session.release();

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -265,6 +265,7 @@ public class MetadataManager {
         // Links the media session
         style.setMediaSession(session.getSessionToken());
 
+
         // Updates the compact media buttons for the notification
         if(!compact.isEmpty()) {
             int[] compactIndexes = new int[compact.size()];
@@ -305,7 +306,8 @@ public class MetadataManager {
         }
 
         session.setActive(false);
-        //session.release();
+        session.release();
+        updateNotification();
     }
 
     private void updateNotification() {

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -294,20 +294,24 @@ public class MetadataManager {
     }
 
     public void destroy() {
+        Log.d(Utils.LOG, "Destroy!");
+
         if(foreground) {
             NotificationManagerCompat.from(service).cancel(1);
         } else {
-            service.stopForeground(false);
+            service.stopForeground(true);
         }
 
         session.setActive(false);
         session.release();
-        updateNotification();
+
+
     }
 
     private void updateNotification() {
         int state = manager.getPlayback().getState();
         if (Utils.isStopped(state)) {
+            Log.d(Utils.LOG, "updateNotification: isStopped");
             removeNotifications();
             return;
         }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 
 import static android.support.v4.media.MediaMetadataCompat.*;
+import static com.guichaguri.trackplayer.service.Utils.bundleToJson;
 
 /**
  * @author Guichaguri
@@ -101,17 +102,7 @@ public class Track {
 
         queueId = System.currentTimeMillis();
 
-        json = new JSONObject();
-        Set<String> keys = bundle.keySet();
-        for (String key : keys) {
-            try {
-                // json.put(key, bundle.get(key)); see edit below
-                json.put(key, JSONObject.wrap(bundle.get(key)));
-            } catch(JSONException e) {
-                //Handle exception here
-                Log.d(Utils.LOG, "Something went Track, creating json");
-            }
-        }
+        json = bundleToJson(bundle);
 
         originalItem = bundle;
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -7,6 +7,8 @@ import android.support.v4.media.MediaDescriptionCompat;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaSessionCompat.QueueItem;
+import android.util.Log;
+
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
@@ -21,8 +23,13 @@ import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.util.Util;
 import com.guichaguri.trackplayer.service.Utils;
 import com.guichaguri.trackplayer.service.player.ExoPlayback;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static android.support.v4.media.MediaMetadataCompat.*;
 
@@ -61,6 +68,7 @@ public class Track {
     public String genre;
     public long duration;
     public Bundle originalItem;
+    public JSONObject json;
 
     public RatingCompat rating;
 
@@ -92,7 +100,21 @@ public class Track {
         rating = Utils.getRating(bundle, "rating", ratingType);
 
         queueId = System.currentTimeMillis();
+
+        json = new JSONObject();
+        Set<String> keys = bundle.keySet();
+        for (String key : keys) {
+            try {
+                // json.put(key, bundle.get(key)); see edit below
+                json.put(key, JSONObject.wrap(bundle.get(key)));
+            } catch(JSONException e) {
+                //Handle exception here
+                Log.d(Utils.LOG, "Something went Track, creating json");
+            }
+        }
+
         originalItem = bundle;
+
     }
 
     public MediaMetadataCompat.Builder toMediaMetadata() {

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -104,7 +104,13 @@ public class ExoPlayback implements EventListener {
         }
 
         queue.addAll(index, tracks);
-        source.addMediaSources(index, trackList, Utils.toRunnable(promise));
+        if(promise != null) {
+            source.addMediaSources(index, trackList, Utils.toRunnable(promise));
+        } else {
+            // Empty promise! Does this have consequences?
+            source.addMediaSources(index, trackList);
+        }
+
 
         if (queue.size() == tracks.size()) {
             player.prepare(source);


### PR DESCRIPTION
Caches queue when service is killed.

Works for our setup, but we only ever have one track in the queue, so it might need some work for others.

I had trouble understanding the notifications, so i simply replaced the notification after it is removed. 
This causes a brief moment where the notification is gone and replaced, when resuming the playback and when the service is killed.