### PR TITLE
get duration from track

### DIFF
--- a/lib/ProgressComponent.js
+++ b/lib/ProgressComponent.js
@@ -31,10 +31,16 @@ class ProgressComponent extends Component {
         // TODO check for performance here
         // We can create a new native function to reduces these 3 native calls to only one, if needed
         try {
+            duration = await TrackPlayer.getDuration();
+            if (!duration){
+                currentTrackId = await TrackPlayer.getCurrentTrack();
+                currentTrack = await TrackPlayer.getTrack(currentTrackId);
+                duration= currentTrack.duration;
+            }
             const data = {
                 position: await TrackPlayer.getPosition(),
                 bufferedPosition: await TrackPlayer.getBufferedPosition(),
-                duration: await TrackPlayer.getDuration()
+                duration: duration
             };
 
             if(this._progressUpdates) {


### PR DESCRIPTION
duration when playing from URL is always zero in iOS, as it happened for me here #359, if you could replicate this issue, then you could update duration from track info.
this PR checks if the duration is zero or not, if so, gets the duration from track's config.