### PR TITLE
Icecast and Shoutcast metadata detect [Android]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ xcuserdata/
 *.dSYM
 example/ios/Pods
 /ios/RNTrackPlayer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+
+
+## Visual Code Project
+*.settings
+*.classpath
+*.project

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-boolean dash = false, hls = false, smoothstreaming = false, icymetadata = false
+boolean dash = false, hls = false, smoothstreaming = false, icy = false
 
 File file = file('../../../track-player.json')
 if(file.exists()) {
@@ -20,7 +20,7 @@ if(file.exists()) {
     dash = json.dash ?: dash
     hls = json.hls ?: hls
     smoothstreaming = json.smoothstreaming ?: smoothstreaming
-    icymetadata = json.icymetadata ?: icymetadata
+    icy = json.icy ?: icy
 }
 
 android {
@@ -85,8 +85,8 @@ dependencies {
         compileOnly 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.9.2'
     }
     
-    // ExoPlayer IcyMetaData
-    if(icymetadata) {
+    // ExoPlayer Icy Extension
+    if (icy) {
         implementation 'saschpe.android:exoplayer2-ext-icy:2.1.0'
     } else {
         compileOnly 'saschpe.android:exoplayer2-ext-icy:2.1.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-boolean dash = false, hls = false, smoothstreaming = false
+boolean dash = false, hls = false, smoothstreaming = false, icymetadata = false
 
 File file = file('../../../track-player.json')
 if(file.exists()) {
@@ -20,6 +20,7 @@ if(file.exists()) {
     dash = json.dash ?: dash
     hls = json.hls ?: hls
     smoothstreaming = json.smoothstreaming ?: smoothstreaming
+    icymetadata = json.icymetadata ?: icymetadata
 }
 
 android {
@@ -82,6 +83,13 @@ dependencies {
         implementation 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.9.2'
     } else {
         compileOnly 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.9.2'
+    }
+    
+    // ExoPlayer IcyMetaData
+    if(icymetadata) {
+        implementation 'saschpe.android:exoplayer2-ext-icy:2.1.0'
+    } else {
+        compileOnly 'saschpe.android:exoplayer2-ext-icy:2.1.0'
     }
 
     // Make sure we're using at least the support library 27.1.1

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicEvents.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicEvents.java
@@ -35,9 +35,7 @@ public class MusicEvents extends BroadcastReceiver {
     public static final String PLAYBACK_QUEUE_ENDED = "playback-queue-ended";
     public static final String PLAYBACK_ERROR = "playback-error";
     public static final String PLAYBACK_UNBIND = "playback-unbind";
-
-    // Icy Metadata Events
-    public static final String ICY_UPDATE = "icy-update";
+    public static final String PLAYBACK_METADATA = "playback-metadata-received";
 
     private final ReactContext reactContext;
 

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicEvents.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicEvents.java
@@ -36,6 +36,9 @@ public class MusicEvents extends BroadcastReceiver {
     public static final String PLAYBACK_ERROR = "playback-error";
     public static final String PLAYBACK_UNBIND = "playback-unbind";
 
+    // Icy Metadata Events
+    public static final String ICY_UPDATE = "icy-update";
+
     private final ReactContext reactContext;
 
     public MusicEvents(ReactContext reactContext) {

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -31,6 +31,7 @@ import com.guichaguri.trackplayer.service.player.ExoPlayback;
 import com.guichaguri.trackplayer.service.player.LocalPlayback;
 
 import static com.google.android.exoplayer2.DefaultLoadControl.*;
+import saschpe.exoplayer2.ext.icy.IcyHttpDataSource.*;
 
 /**
  * @author Guichaguri
@@ -58,6 +59,16 @@ public class MusicManager implements OnAudioFocusChangeListener {
     private boolean receivingNoisyEvents = false;
 
     private boolean stopWithApp = false;
+
+    private IcyMetadataListener icyMetadaUpdate = new IcyMetadataListener() {
+        @Override
+        public void onIcyMetaData(IcyMetadata icyMetadata) {             
+            Bundle bundle = new Bundle();
+            bundle.putString("streamTitle", icyMetadata.getStreamTitle());
+            bundle.putString("streamUrl", icyMetadata.getStreamUrl());
+            service.emit(MusicEvents.ICY_UPDATE, bundle);      
+        }
+    };
 
     @SuppressLint("InvalidWakeLockTag")
     public MusicManager(MusicService service) {
@@ -312,5 +323,9 @@ public class MusicManager implements OnAudioFocusChangeListener {
         // Release the locks
         if(wifiLock.isHeld()) wifiLock.release();
         if(wakeLock.isHeld()) wakeLock.release();
+    }
+
+    public IcyMetadataListener onIcyMetadaUpdate(){
+        return icyMetadaUpdate;
     }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -31,7 +31,6 @@ import com.guichaguri.trackplayer.service.player.ExoPlayback;
 import com.guichaguri.trackplayer.service.player.LocalPlayback;
 
 import static com.google.android.exoplayer2.DefaultLoadControl.*;
-import saschpe.exoplayer2.ext.icy.IcyHttpDataSource.*;
 
 /**
  * @author Guichaguri
@@ -59,16 +58,6 @@ public class MusicManager implements OnAudioFocusChangeListener {
     private boolean receivingNoisyEvents = false;
 
     private boolean stopWithApp = false;
-
-    private IcyMetadataListener icyMetadaUpdate = new IcyMetadataListener() {
-        @Override
-        public void onIcyMetaData(IcyMetadata icyMetadata) {             
-            Bundle bundle = new Bundle();
-            bundle.putString("streamTitle", icyMetadata.getStreamTitle());
-            bundle.putString("streamUrl", icyMetadata.getStreamUrl());
-            service.emit(MusicEvents.ICY_UPDATE, bundle);      
-        }
-    };
 
     @SuppressLint("InvalidWakeLockTag")
     public MusicManager(MusicService service) {
@@ -323,9 +312,5 @@ public class MusicManager implements OnAudioFocusChangeListener {
         // Release the locks
         if(wifiLock.isHeld()) wifiLock.release();
         if(wakeLock.isHeld()) wakeLock.release();
-    }
-
-    public IcyMetadataListener onIcyMetadaUpdate(){
-        return icyMetadaUpdate;
     }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/IcyEvents.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/IcyEvents.java
@@ -1,18 +1,32 @@
 package com.guichaguri.trackplayer.service.metadata;
 
 import android.os.Bundle;
+import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.guichaguri.trackplayer.module.MusicEvents;
 import com.guichaguri.trackplayer.service.MusicService;
+import com.google.android.exoplayer2.upstream.DataSource;
 import saschpe.exoplayer2.ext.icy.IcyHttpDataSource;
+import saschpe.exoplayer2.ext.icy.IcyHttpDataSourceFactory;
 
 import java.util.HashMap;
 
 public class IcyEvents implements IcyHttpDataSource.IcyMetadataListener, IcyHttpDataSource.IcyHeadersListener {
 
     private final MusicService service;
+    private final DataSource.Factory ds;
 
-    public IcyEvents(MusicService service) {
+    public IcyEvents(MusicService service, String userAgent) {
         this.service = service;
+
+        this.ds = new IcyHttpDataSourceFactory.Builder(OkHttpClientProvider.getOkHttpClient())
+        .setUserAgent(userAgent)
+        .setIcyMetadataChangeListener(this)
+        .setIcyHeadersListener(this)
+        .build();
+    }
+
+    public DataSource.Factory getIcyDataSource() {
+        return ds;
     }
 
     @Override

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/IcyEvents.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/IcyEvents.java
@@ -1,0 +1,51 @@
+package com.guichaguri.trackplayer.service.metadata;
+
+import android.os.Bundle;
+import com.guichaguri.trackplayer.module.MusicEvents;
+import com.guichaguri.trackplayer.service.MusicService;
+import saschpe.exoplayer2.ext.icy.IcyHttpDataSource;
+
+import java.util.HashMap;
+
+public class IcyEvents implements IcyHttpDataSource.IcyMetadataListener, IcyHttpDataSource.IcyHeadersListener {
+
+    private final MusicService service;
+
+    public IcyEvents(MusicService service) {
+        this.service = service;
+    }
+
+    @Override
+    public void onIcyMetaData(IcyHttpDataSource.IcyMetadata metadata) {
+        Bundle bundle = new Bundle();
+        Bundle fullMetadata = new Bundle();
+
+        bundle.putString("type", "icy-metadata");
+        bundle.putString("title", metadata.getStreamTitle());
+        bundle.putString("url", metadata.getStreamUrl());
+
+        HashMap<String, String> data = metadata.getMetadata();
+        for(String key : data.keySet()) {
+            fullMetadata.putString(key, data.get(key));
+        }
+
+        bundle.putBundle("metadata", fullMetadata);
+
+        service.emit(MusicEvents.PLAYBACK_METADATA, bundle);
+    }
+
+    @Override
+    public void onIcyHeaders(IcyHttpDataSource.IcyHeaders headers) {
+        Bundle bundle = new Bundle();
+
+        bundle.putString("type", "icy-headers");
+        bundle.putString("name", headers.getName());
+        bundle.putString("genre", headers.getGenre());
+        bundle.putString("url", headers.getUrl());
+        bundle.putInt("bitrate", headers.getBitRate());
+        bundle.putBoolean("public", headers.isPublic());
+
+        service.emit(MusicEvents.PLAYBACK_METADATA, bundle);
+    }
+
+}

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -181,7 +181,7 @@ public class Track {
             ds = new IcyHttpDataSourceFactory.Builder(OkHttpClientProvider.getOkHttpClient())
                     .setUserAgent(userAgent)
                     .setIcyMetadataChangeListener(listener)
-                    .setIcyMetadataChangeListener(listener)
+                    .setIcyHeadersListener(listener)
                     .build();
 
             ds = new DefaultDataSourceFactory(ctx, null, ds);

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -23,9 +23,6 @@ import com.guichaguri.trackplayer.service.Utils;
 import com.guichaguri.trackplayer.service.metadata.IcyEvents;
 import com.guichaguri.trackplayer.service.player.LocalPlayback;
 
-import saschpe.exoplayer2.ext.icy.IcyHttpDataSourceFactory;
-import okhttp3.OkHttpClient;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -176,15 +173,9 @@ public class Track {
         } else if(type == TrackType.ICY) {
 
             // Creates a data source that intercepts icy metadata
-            IcyEvents listener = new IcyEvents(ctx);
+            IcyEvents listener = new IcyEvents(ctx, userAgent);
 
-            ds = new IcyHttpDataSourceFactory.Builder(OkHttpClientProvider.getOkHttpClient())
-                    .setUserAgent(userAgent)
-                    .setIcyMetadataChangeListener(listener)
-                    .setIcyHeadersListener(listener)
-                    .build();
-
-            ds = new DefaultDataSourceFactory(ctx, null, ds);
+            ds = new DefaultDataSourceFactory(ctx, null, listener.getIcyDataSource());
 
             ds = playback.enableCaching(ds);
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -19,6 +19,9 @@ import com.google.android.exoplayer2.util.Util;
 import com.guichaguri.trackplayer.service.Utils;
 import com.guichaguri.trackplayer.service.player.LocalPlayback;
 
+import saschpe.exoplayer2.ext.icy.IcyHttpDataSourceFactory;
+import okhttp3.OkHttpClient;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -165,6 +168,20 @@ public class Track {
 
             // Creates a local source factory
             ds = new DefaultDataSourceFactory(ctx, userAgent);
+
+        } else if(type == TrackType.ICY) {
+
+            // Create a streaming HTTP source factory, enabling icy-metadata
+            OkHttpClient client = new OkHttpClient.Builder().build();
+            IcyHttpDataSourceFactory icyDataSource = new IcyHttpDataSourceFactory
+                    .Builder(client)
+                    .setUserAgent(userAgent)
+                    .setIcyMetadataChangeListener(playback.onIcyMetadaUpdate())
+                    .build();
+
+            ds = new DefaultDataSourceFactory(ctx, null, icyDataSource);
+
+            ds = playback.enableCaching(ds);
 
         } else {
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/TrackType.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/TrackType.java
@@ -26,9 +26,9 @@ public enum TrackType {
     SMOOTH_STREAMING("smoothstreaming"),
     
     /**
-     * The Icy midia type. Should be used for streams over HTTP (Icecast/Shoutcast)
+     * The Icy media type. Should be used for Icecast/Shoutcast streams
      */
-    ICY("ICY");
+    ICY("icy");
 
 
     public final String name;

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/TrackType.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/TrackType.java
@@ -23,7 +23,12 @@ public enum TrackType {
     /**
      * The SmoothStreaming media type for adaptive streams. Should be used with SmoothStreaming manifests
      */
-    SMOOTH_STREAMING("smoothstreaming");
+    SMOOTH_STREAMING("smoothstreaming"),
+    
+    /**
+     * The Icy midia type. Should be used for streams over HTTP (Icecast/Shoutcast)
+     */
+    ICY("ICY");
 
 
     public final String name;

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -16,6 +16,7 @@ import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.guichaguri.trackplayer.service.MusicManager;
 import com.guichaguri.trackplayer.service.Utils;
 import com.guichaguri.trackplayer.service.models.Track;
+import saschpe.exoplayer2.ext.icy.IcyHttpDataSource.IcyMetadataListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -284,5 +285,9 @@ public abstract class ExoPlayback<T extends Player> implements EventListener {
     @Override
     public void onSeekProcessed() {
         // Finished seeking
+    }
+   
+    public IcyMetadataListener onIcyMetadaUpdate(){
+        return manager.onIcyMetadaUpdate();
     }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -14,6 +14,7 @@ import com.google.android.exoplayer2.Timeline.Window;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.guichaguri.trackplayer.service.MusicManager;
+import com.guichaguri.trackplayer.service.MusicService;
 import com.guichaguri.trackplayer.service.Utils;
 import com.guichaguri.trackplayer.service.models.Track;
 import saschpe.exoplayer2.ext.icy.IcyHttpDataSource.IcyMetadataListener;
@@ -27,7 +28,7 @@ import java.util.List;
  */
 public abstract class ExoPlayback<T extends Player> implements EventListener {
 
-    protected final Context context;
+    protected final MusicService context;
     protected final MusicManager manager;
     protected final T player;
 
@@ -38,7 +39,7 @@ public abstract class ExoPlayback<T extends Player> implements EventListener {
     protected long lastKnownPosition = C.POSITION_UNSET;
     protected int previousState = PlaybackStateCompat.STATE_NONE;
 
-    public ExoPlayback(Context context, MusicManager manager, T player) {
+    public ExoPlayback(MusicService context, MusicManager manager, T player) {
         this.context = context;
         this.manager = manager;
         this.player = player;
@@ -285,9 +286,5 @@ public abstract class ExoPlayback<T extends Player> implements EventListener {
     @Override
     public void onSeekProcessed() {
         // Finished seeking
-    }
-   
-    public IcyMetadataListener onIcyMetadaUpdate(){
-        return manager.onIcyMetadaUpdate();
     }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
@@ -1,6 +1,5 @@
 package com.guichaguri.trackplayer.service.player;
 
-import android.content.Context;
 import android.util.Log;
 import com.facebook.react.bridge.Promise;
 import com.google.android.exoplayer2.C;
@@ -15,8 +14,10 @@ import com.google.android.exoplayer2.upstream.cache.CacheDataSourceFactory;
 import com.google.android.exoplayer2.upstream.cache.LeastRecentlyUsedCacheEvictor;
 import com.google.android.exoplayer2.upstream.cache.SimpleCache;
 import com.guichaguri.trackplayer.service.MusicManager;
+import com.guichaguri.trackplayer.service.MusicService;
 import com.guichaguri.trackplayer.service.Utils;
 import com.guichaguri.trackplayer.service.models.Track;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,7 +35,7 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
     private ConcatenatingMediaSource source;
     private boolean prepared = false;
 
-    public LocalPlayback(Context context, MusicManager manager, SimpleExoPlayer player, long maxCacheSize) {
+    public LocalPlayback(MusicService context, MusicManager manager, SimpleExoPlayer player, long maxCacheSize) {
         super(context, manager, player);
         this.cacheMaxSize = maxCacheSize;
     }


### PR DESCRIPTION

Metadata detection was implemented, using the code created by @saschpe ([android-exoplayer2-ext-icy](https://github.com/saschpe/android-exoplayer2-ext-icy) or [ExoPlayer](https://github.com/saschpe/ExoPlayer/tree/icy)), where it performs HTTP detection for ExoPlayer.

The `icy-update` event that is called when the meta-date is updated.

```Javascript
this._updateIcyMetaData = TrackPlayer.addEventListener("icy-update", (data) => {
    console.log("icy-update", data);
})
```

Two attributes are sent in this event:
- **streamTitle**: Matches the song title and artist currently playing in streaming.
- **streamUrl**: Contains more information that is sent to Icecast in the format as a link, this information is defined in the software used for the transmission. (In Shoutcast servers this option is not possible to change).


The `icy-header` event was disregarded for this implementation because it was taken into account that it is not "necessary" to use the same event.

The type `ICY` audio was added because the operation with the HLS is possible, but through the @saschpe code the same does not work, because in HLS the sending of the metadata is not at the beginning of the data received obligatorily.

To update the notification, it is recommended to use the code implemented by @HybridFox (#331). Because the direct updating of the information would not be a good thing, because the person can obtain information from the metadata and make a query in an api and with the result obtained to update the notification.

> In the application I'm developing. The cover code of the song is sent in streamUrl, so I make a query in my API.


If you want to test, you can use this Track for testing:
```json
{
    "type": "icy",
    "id": "1111",
    "url": "https://live.hunter.fm/pop2k",
    "title": "Hunter.FM",
    "artist": "The POP2k Channel",
    "artwork": "https://cdn.hunter.fm/image/thumb/station/pop2k-first/300x300ht.jpg"
}
```

> Note: Sorry for the previous code, the same was done after getting many problems with other "players" being so was doing during a time of fatigue.

> Note²: If you want to implement the `icy-header` I can do it.