### PR TITLE
fix get duration compatibility with Swift 4.2

### DIFF
--- a/ios/RNTrackPlayer/Vendor/AudioPlayer/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/ios/RNTrackPlayer/Vendor/AudioPlayer/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -85,7 +85,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     }
 
     var duration: TimeInterval {
-        if let seconds = currentItem?.duration.seconds, !seconds.isNaN {
+        if let seconds = currentItem?.asset.duration.seconds, !seconds.isNaN {
             return seconds
         }
         else if let seconds = currentItem?.loadedTimeRanges.first?.timeRangeValue.duration.seconds,


### PR DESCRIPTION
related issue : https://github.com/react-native-kit/react-native-track-player/issues/407
