### PR TITLE
Feature: enable seeking on mp3's with variable bitrate

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -8,6 +8,7 @@ import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaSessionCompat.QueueItem;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
+import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
@@ -194,6 +195,7 @@ public class Track {
                         .createMediaSource(uri);
             default:
                 return new ExtractorMediaSource.Factory(ds)
+                        .setExtractorsFactory(new DefaultExtractorsFactory().setConstantBitrateSeekingEnabled(true))
                         .createMediaSource(uri);
         }
     }


### PR DESCRIPTION
#418 

https://google.github.io/ExoPlayer/faqs.html#why-are-some-media-files-not-seekable