### PR TITLE
[Android] Use root project's sdk versions if specified

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,13 +22,16 @@ if(file.exists()) {
     smoothstreaming = json.smoothstreaming ?: smoothstreaming
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion safeExtGet("compileSdkVersion", 27)
 
     defaultConfig {
-        minSdkVersion 16 // RN's minimum version
-        targetSdkVersion 27
+        minSdkVersion safeExtGet('minSdkVersion', 16) // RN's minimum version
+        targetSdkVersion safeExtGet("compileSdkVersion", 27)
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,8 +30,9 @@ android {
     compileSdkVersion safeExtGet("compileSdkVersion", 27)
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16) // RN's minimum version
-        targetSdkVersion safeExtGet("compileSdkVersion", 27)
+        minSdkVersion safeExtGet("minSdkVersion", 16) // RN's minimum version
+        targetSdkVersion safeExtGet("targetSdkVersion", 27)
+
         versionCode 1
         versionName "1.0"
         ndk {
@@ -88,8 +89,7 @@ dependencies {
     }
 
     // Make sure we're using at least the support library 27.1.1
-    implementation 'com.android.support:support-compat:27.1.1'
-    implementation 'com.android.support:support-media-compat:27.1.1'
-
+    implementation "com.android.support:support-compat:${safeExtGet('supportLibVersion', '27.1.1')}"
+    implementation "com.android.support:support-media-compat:${safeExtGet('supportLibVersion', '27.1.1')}"
     implementation 'com.github.bumptech.glide:glide:4.7.1'
 }


### PR DESCRIPTION
This is a popular strategy for react native plugins and fixes several issues. I recently upgraded react native and the default sdk for react native 0.58.4 is 28. Rather than updating it manually in RNTP, I suggest using whatever sdk is being used in the parent project. For my purposes, RNTP seems to work fine with 28. Projects still on 27 are not affected by this change.

Also, each sdk has a default build tools version associated with it. Sometimes the buildToolsVersion setting is completely ignored if it doesn't match the sdk. There's no need to set it.