### PR TITLE
Update podspec to pull from the tag

### DIFF
--- a/react-native-track-player.podspec
+++ b/react-native-track-player.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/react-native-kit/react-native-track-player"
   s.license      = "Apache-2.0"
   s.platform     = :ios, "9.0"
-  s.source       = { :git => "https://github.com/react-native-kit/react-native-track-player.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/react-native-kit/react-native-track-player.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,swift}"
   s.dependency "React"
 end


### PR DESCRIPTION
#437 
Podspec takes the version from package.json, to pull corresponding tag or branch, but fails because one doesn't exist. There are no version branches, only version tags with a `v` appended. Appending an `v` to the `version` will pick the relevant tag.