### PR TITLE
Add missing calls to resolveAsset for rewindIcon and forwardIcon.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,8 @@ function updateOptions(data) {
     data.stopIcon = resolveAsset(data.stopIcon);
     data.previousIcon = resolveAsset(data.previousIcon);
     data.nextIcon = resolveAsset(data.nextIcon);
+    data.rewindIcon = resolveAsset(data.rewindIcon);
+    data.forwardIcon = resolveAsset(data.forwardIcon);
 
     return TrackPlayer.updateOptions(data);
 }


### PR DESCRIPTION
I was having trouble getting custom icons to show up in Android notification for jumping forward and rewinding.

I discovered these assets were not using the same `resolveAsset` code that the other icons were.