### PR TITLE
[Android] Add ability to set back buffer.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,13 +22,17 @@ if(file.exists()) {
     smoothstreaming = json.smoothstreaming ?: smoothstreaming
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion safeExtGet("compileSdkVersion", 27)
 
     defaultConfig {
-        minSdkVersion 16 // RN's minimum version
-        targetSdkVersion 27
+        minSdkVersion safeExtGet("minSdkVersion", 16) // RN's minimum version
+        targetSdkVersion safeExtGet("targetSdkVersion", 27)
+
         versionCode 1
         versionName "1.0"
         ndk {
@@ -85,8 +89,7 @@ dependencies {
     }
 
     // Make sure we're using at least the support library 27.1.1
-    implementation 'com.android.support:support-compat:27.1.1'
-    implementation 'com.android.support:support-media-compat:27.1.1'
-
+    implementation "com.android.support:support-compat:${safeExtGet('supportLibVersion', '27.1.1')}"
+    implementation "com.android.support:support-media-compat:${safeExtGet('supportLibVersion', '27.1.1')}"
     implementation 'com.github.bumptech.glide:glide:4.7.1'
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -113,8 +113,8 @@ public class MusicManager implements OnAudioFocusChangeListener {
 
         LoadControl control = new DefaultLoadControl.Builder()
                 .setBufferDurationsMs(minBuffer, maxBuffer, playBuffer, playBuffer * multiplier)
-				.setBackBuffer(backBuffer, false)
-				.createDefaultLoadControl();
+                .setBackBuffer(backBuffer, false)
+                .createDefaultLoadControl();
 
         SimpleExoPlayer player = ExoPlayerFactory.newSimpleInstance(service, new DefaultRenderersFactory(service), new DefaultTrackSelector(), control);
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -107,12 +107,14 @@ public class MusicManager implements OnAudioFocusChangeListener {
         int minBuffer = (int)Utils.toMillis(options.getDouble("minBuffer", Utils.toSeconds(DEFAULT_MIN_BUFFER_MS)));
         int maxBuffer = (int)Utils.toMillis(options.getDouble("maxBuffer", Utils.toSeconds(DEFAULT_MAX_BUFFER_MS)));
         int playBuffer = (int)Utils.toMillis(options.getDouble("playBuffer", Utils.toSeconds(DEFAULT_BUFFER_FOR_PLAYBACK_MS)));
+        int backBuffer = (int)Utils.toMillis(options.getDouble("backBuffer", Utils.toSeconds(DEFAULT_BACK_BUFFER_DURATION_MS)));
         long cacheMaxSize = (long)(options.getDouble("maxCacheSize", 0) * 1024);
         int multiplier = DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS / DEFAULT_BUFFER_FOR_PLAYBACK_MS;
 
         LoadControl control = new DefaultLoadControl.Builder()
                 .setBufferDurationsMs(minBuffer, maxBuffer, playBuffer, playBuffer * multiplier)
-                .createDefaultLoadControl();
+				.setBackBuffer(backBuffer, false)
+				.createDefaultLoadControl();
 
         SimpleExoPlayer player = ExoPlayerFactory.newSimpleInstance(service, new DefaultRenderersFactory(service), new DefaultTrackSelector(), control);
 


### PR DESCRIPTION
This enables optionally setting a `backBuffer` option in `setupPlayer(options)`.

If the value is not set it will default to the exoplayer default, which is 0.

Having no back buffer is not always ideal because if your UI allows seeking or jumping backwards, the buffer does not contain anything behind the current playhead, and will need to re-load. Additionally, when it DOES reload any current buffer progress in the future is also lost.

I would also update the documentation if I knew how. From what I can tell there isn't a way in include wiki edits in this pull request.

Here are my proposed documentation updates if you'd like to copy them in. Added default values as well.

```
| Param   | Type     | Description   | Default   |
| ------- | -------- | ------------- | ------------- |
| options | `object` | The options   | |
| options.minBuffer | `number` | Minimum time in seconds that needs to be buffered | 15 |
| options.maxBuffer | `number` | Maximum time in seconds that needs to be buffered | 50 |
| options.playBuffer | `number` | Minimum time in seconds that needs to be buffered to start playing | 2.5 |
| options.backBuffer | `number` | Time in seconds that should be kept in the buffer behind the current playhead time. | 0 |
| options.maxCacheSize | `number` | Maximum cache size in kilobytes | 0 |
```