### PR TITLE
Add a function to update a track metadata

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,13 +22,17 @@ if(file.exists()) {
     smoothstreaming = json.smoothstreaming ?: smoothstreaming
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion safeExtGet("compileSdkVersion", 27)
 
     defaultConfig {
-        minSdkVersion 16 // RN's minimum version
-        targetSdkVersion 27
+        minSdkVersion safeExtGet("minSdkVersion", 16) // RN's minimum version
+        targetSdkVersion safeExtGet("targetSdkVersion", 27)
+
         versionCode 1
         versionName "1.0"
         ndk {
@@ -85,8 +89,7 @@ dependencies {
     }
 
     // Make sure we're using at least the support library 27.1.1
-    implementation 'com.android.support:support-compat:27.1.1'
-    implementation 'com.android.support:support-media-compat:27.1.1'
-
+    implementation "com.android.support:support-compat:${safeExtGet('supportLibVersion', '27.1.1')}"
+    implementation "com.android.support:support-media-compat:${safeExtGet('supportLibVersion', '27.1.1')}"
     implementation 'com.github.bumptech.glide:glide:4.7.1'
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -16,6 +16,8 @@ import com.guichaguri.trackplayer.service.MusicBinder;
 import com.guichaguri.trackplayer.service.MusicService;
 import com.guichaguri.trackplayer.service.Utils;
 import com.guichaguri.trackplayer.service.models.Track;
+import com.guichaguri.trackplayer.service.player.ExoPlayback;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -237,6 +239,33 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
 
             if (indexes.size() > 0) {
                 binder.getPlayback().remove(indexes, callback);
+            }
+        });
+    }
+
+    @ReactMethod
+    public void updateMetadata(String id, ReadableMap map, final Promise callback) {
+        waitForConnection(() -> {
+            ExoPlayback playback = binder.getPlayback();
+            List<Track> queue = playback.getQueue();
+            Track track = null;
+            int index = -1;
+
+            for(int i = 0; i < queue.size(); i++) {
+                track = queue.get(i);
+
+                if(track.id.equals(id)) {
+                    index = i;
+                    break;
+                }
+            }
+
+            if(index == -1) {
+                callback.reject("track_not_in_queue", "No track found");
+            } else {
+                track.setMetadata(getReactApplicationContext(), Arguments.toBundle(map), binder.getRatingType());
+                playback.updateTrack(index, track);
+                callback.resolve(null);
             }
         });
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -244,7 +244,7 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     }
 
     @ReactMethod
-    public void updateMetadata(String id, ReadableMap map, final Promise callback) {
+    public void updateMetadataForTrack(String id, ReadableMap map, final Promise callback) {
         waitForConnection(() -> {
             ExoPlayback playback = binder.getPlayback();
             List<Track> queue = playback.getQueue();

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -107,11 +107,13 @@ public class MusicManager implements OnAudioFocusChangeListener {
         int minBuffer = (int)Utils.toMillis(options.getDouble("minBuffer", Utils.toSeconds(DEFAULT_MIN_BUFFER_MS)));
         int maxBuffer = (int)Utils.toMillis(options.getDouble("maxBuffer", Utils.toSeconds(DEFAULT_MAX_BUFFER_MS)));
         int playBuffer = (int)Utils.toMillis(options.getDouble("playBuffer", Utils.toSeconds(DEFAULT_BUFFER_FOR_PLAYBACK_MS)));
+        int backBuffer = (int)Utils.toMillis(options.getDouble("backBuffer", Utils.toSeconds(DEFAULT_BACK_BUFFER_DURATION_MS)));
         long cacheMaxSize = (long)(options.getDouble("maxCacheSize", 0) * 1024);
         int multiplier = DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS / DEFAULT_BUFFER_FOR_PLAYBACK_MS;
 
         LoadControl control = new DefaultLoadControl.Builder()
                 .setBufferDurationsMs(minBuffer, maxBuffer, playBuffer, playBuffer * multiplier)
+                .setBackBuffer(backBuffer, false)
                 .createDefaultLoadControl();
 
         SimpleExoPlayer player = ExoPlayerFactory.newSimpleInstance(service, new DefaultRenderersFactory(service), new DefaultTrackSelector(), control);

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -226,22 +226,26 @@ public class MusicManager implements OnAudioFocusChangeListener {
     public void onAudioFocusChange(int focus) {
         Log.d(Utils.LOG, "onDuck");
 
+        boolean permanent = false;
         boolean paused = false;
         boolean ducking = false;
 
         switch(focus) {
             case AudioManager.AUDIOFOCUS_LOSS:
+                permanent = true;
+                abandonFocus();
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 paused = true;
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
                 ducking = true;
                 break;
-            case AudioManager.AUDIOFOCUS_GAIN:
+            default:
                 break;
         }
 
         Bundle bundle = new Bundle();
+        bundle.putBoolean("permanent", permanent);
         bundle.putBoolean("paused", paused);
         bundle.putBoolean("ducking", ducking);
         service.emit(MusicEvents.BUTTON_DUCK, bundle);

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -90,6 +90,14 @@ public class Track {
 
         contentType = bundle.getString("contentType");
         userAgent = bundle.getString("userAgent");
+
+        setMetadata(context, bundle, ratingType);
+
+        queueId = System.currentTimeMillis();
+        originalItem = bundle;
+    }
+
+    public void setMetadata(Context context, Bundle bundle, int ratingType) {
         artwork = Utils.getUri(context, bundle, "artwork");
 
         title = bundle.getString("title");
@@ -100,9 +108,6 @@ public class Track {
         duration = Utils.toMillis(bundle.getDouble("duration", 0));
 
         rating = Utils.getRating(bundle, "rating", ratingType);
-
-        queueId = System.currentTimeMillis();
-        originalItem = bundle;
     }
 
     public MediaMetadataCompat.Builder toMediaMetadata() {

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -108,6 +108,9 @@ public class Track {
         duration = Utils.toMillis(bundle.getDouble("duration", 0));
 
         rating = Utils.getRating(bundle, "rating", ratingType);
+        
+        if (originalItem != null && originalItem != bundle)
+            originalItem.putAll(bundle);
     }
 
     public MediaMetadataCompat.Builder toMediaMetadata() {

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -59,6 +59,15 @@ public abstract class ExoPlayback<T extends Player> implements EventListener {
 
     public abstract void removeUpcomingTracks();
 
+    public void updateTrack(int index, Track track) {
+        int currentIndex = player.getCurrentWindowIndex();
+
+        queue.set(index, track);
+
+        if(currentIndex == index)
+            manager.getMetadata().updateMetadata(track);
+    }
+
     public Track getCurrentTrack() {
         int index = player.getCurrentWindowIndex();
         return index == C.INDEX_UNSET || index < 0 || index >= queue.size() ? null : queue.get(index);

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -207,6 +207,15 @@ Gets the whole queue
 #### `removeUpcomingTracks()`
 Clears any upcoming tracks from the queue.
 
+#### `updateMetadata(id, metadata)`
+
+**Returns:** `Promise`
+
+| Param    | Type       | Description   |
+| -------- | ---------- | ------------- |
+| id       | `string`   | The track ID  |
+| metadata | `object`   | A subset of the [Track Object](#track-object) with only the `artwork`, `title`, `artist`, `album`, `description`, `genre`, `date`, `rating` and `duration` properties. |
+
 ### Player Functions
 #### `updateOptions(options)`
 Updates the configuration for the components.

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -209,6 +209,7 @@ Clears any upcoming tracks from the queue.
 
 #### `updateMetadataForTrack(id, metadata)`
 Updates the metadata of a track in the queue.
+If the current track is updated, the notification and the Now Playing Center will be updated accordingly.
 
 **Returns:** `Promise`
 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -207,7 +207,8 @@ Gets the whole queue
 #### `removeUpcomingTracks()`
 Clears any upcoming tracks from the queue.
 
-#### `updateMetadata(id, metadata)`
+#### `updateMetadataForTrack(id, metadata)`
+Updates the metadata of a track in the queue.
 
 **Returns:** `Promise`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,12 +45,7 @@ declare namespace RNTrackPlayer {
   type EmitterSubscription = { remove: () => void; };
   export function addEventListener(type: EventType, listener: (data: any) => void): EmitterSubscription;
 
-  export interface Track {
-    id: string;
-    url: string | ResourceObject;
-    type?: TrackType;
-    userAgent?: string;
-    contentType?: string;
+  export interface TrackMetadata {
     duration?: number;
     title: string;
     artist: string;
@@ -60,6 +55,14 @@ declare namespace RNTrackPlayer {
     date?: string;
     rating?: number | boolean;
     artwork?: string | ResourceObject;
+  }
+
+  export interface Track extends TrackMetadata {
+    id: string;
+    url: string | ResourceObject;
+    type?: TrackType;
+    userAgent?: string;
+    contentType?: string;
     pitchAlgorithm?: PitchAlgorithm;
     [key: string]: any;
   }
@@ -104,6 +107,7 @@ declare namespace RNTrackPlayer {
   export function skip(trackId: string): Promise<void>;
   export function skipToNext(): Promise<void>;
   export function skipToPrevious(): Promise<void>;
+  export function updateMetadata(id: string, metadata: TrackMetadata) : Promise<void>;
   export function removeUpcomingTracks(): Promise<void>;
 
   // Player Playback Commands

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,7 +111,7 @@ declare namespace RNTrackPlayer {
   export function skip(trackId: string): Promise<void>;
   export function skipToNext(): Promise<void>;
   export function skipToPrevious(): Promise<void>;
-  export function updateMetadata(id: string, metadata: TrackMetadata) : Promise<void>;
+  export function updateMetadataForTrack(id: string, metadata: TrackMetadata) : Promise<void>;
   export function removeUpcomingTracks(): Promise<void>;
 
   // Player Playback Commands

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -152,6 +152,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
         let capabilities = supportedCapabilities?.compactMap { Capability(rawValue: $0) } ?? []
         
         let remoteCommands = capabilities.map { $0.mapToPlayerCommand(jumpInterval: options["jumpInterval"] as? NSNumber) }
+        player.remoteCommands.removeAll()
         player.remoteCommands.append(contentsOf: remoteCommands)
         
         player.remoteCommandController.handleChangePlaybackPositionCommand = { [weak self] event in

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,8 @@ function updateOptions(data) {
     data.stopIcon = resolveAsset(data.stopIcon);
     data.previousIcon = resolveAsset(data.previousIcon);
     data.nextIcon = resolveAsset(data.nextIcon);
+    data.rewindIcon = resolveAsset(data.rewindIcon);
+    data.forwardIcon = resolveAsset(data.forwardIcon);
 
     return TrackPlayer.updateOptions(data);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -169,6 +169,7 @@ module.exports.skip = TrackPlayer.skip;
 module.exports.getQueue = TrackPlayer.getQueue;
 module.exports.skipToNext = TrackPlayer.skipToNext;
 module.exports.skipToPrevious = TrackPlayer.skipToPrevious;
+module.exports.updateMetadata = TrackPlayer.updateMetadata;
 module.exports.removeUpcomingTracks = TrackPlayer.removeUpcomingTracks;
 
 // Player Playback Commands

--- a/lib/index.js
+++ b/lib/index.js
@@ -170,7 +170,7 @@ module.exports.skip = TrackPlayer.skip;
 module.exports.getQueue = TrackPlayer.getQueue;
 module.exports.skipToNext = TrackPlayer.skipToNext;
 module.exports.skipToPrevious = TrackPlayer.skipToPrevious;
-module.exports.updateMetadata = TrackPlayer.updateMetadata;
+module.exports.updateMetadataForTrack = TrackPlayer.updateMetadataForTrack;
 module.exports.removeUpcomingTracks = TrackPlayer.removeUpcomingTracks;
 
 // Player Playback Commands

--- a/react-native-track-player.podspec
+++ b/react-native-track-player.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/react-native-kit/react-native-track-player"
   s.license      = "Apache-2.0"
   s.platform     = :ios, "9.0"
-  s.source       = { :git => "https://github.com/react-native-kit/react-native-track-player.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/react-native-kit/react-native-track-player.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,swift}"
   s.dependency "React"
 end

--- a/windows/RNTrackPlayer.sln
+++ b/windows/RNTrackPlayer.sln
@@ -4,16 +4,17 @@ VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RNTrackPlayer", "RNTrackPlayer\RNTrackPlayer.csproj", "{E292F490-9FB8-11E7-B023-0F938699DB28}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactNative", "..\..\..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj", "{C7673AD5-E3AA-468C-A5FD-FA38154E205C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactNative", "..\..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj", "{C7673AD5-E3AA-468C-A5FD-FA38154E205C}"
 EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ReactNative.Shared", "..\..\..\node_modules\react-native-windows\ReactWindows\ReactNative.Shared\ReactNative.Shared.shproj", "{EEA8B852-4D07-48E1-8294-A21AB5909FE5}"
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ReactNative.Shared", "..\..\node_modules\react-native-windows\ReactWindows\ReactNative.Shared\ReactNative.Shared.shproj", "{EEA8B852-4D07-48E1-8294-A21AB5909FE5}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChakraBridge", "..\..\..\node_modules\react-native-windows\ReactWindows\ChakraBridge\ChakraBridge.vcxproj", "{4B72C796-16D5-4E3A-81C0-3E36F531E578}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChakraBridge", "..\..\node_modules\react-native-windows\ReactWindows\ChakraBridge\ChakraBridge.vcxproj", "{4B72C796-16D5-4E3A-81C0-3E36F531E578}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		..\node_modules\react-native-windows\ReactWindows\ReactNative.Shared\ReactNative.Shared.projitems*{c7673ad5-e3aa-468c-a5fd-fa38154e205c}*SharedItemsImports = 4
-		..\node_modules\react-native-windows\ReactWindows\ReactNative.Shared\ReactNative.Shared.projitems*{eea8b852-4d07-48e1-8294-a21ab5909fe5}*SharedItemsImports = 13
+		..\..\node_modules\react-native-windows\ReactWindows\ReactNative.Shared\ReactNative.Shared.projitems*{c7673ad5-e3aa-468c-a5fd-fa38154e205c}*SharedItemsImports = 4
+		..\..\node_modules\react-native-windows\Yoga\csharp\Facebook.Yoga\Facebook.Yoga.Shared.projitems*{c7673ad5-e3aa-468c-a5fd-fa38154e205c}*SharedItemsImports = 4
+		..\..\node_modules\react-native-windows\ReactWindows\ReactNative.Shared\ReactNative.Shared.projitems*{eea8b852-4d07-48e1-8294-a21ab5909fe5}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM

--- a/windows/RNTrackPlayer/Logic/MediaManager.cs
+++ b/windows/RNTrackPlayer/Logic/MediaManager.cs
@@ -52,6 +52,11 @@ namespace TrackPlayer.Logic
             return player;
         }
 
+        public Metadata GetMetadata()
+        {
+            return metadata;
+        }
+
         public void OnEnd(Track previous, double prevPos)
         {
             Debug.WriteLine("OnEnd");

--- a/windows/RNTrackPlayer/Logic/Metadata.cs
+++ b/windows/RNTrackPlayer/Logic/Metadata.cs
@@ -5,7 +5,7 @@ using Windows.Storage.Streams;
 
 namespace TrackPlayer.Logic
 {
-    class Metadata
+    public class Metadata
     {
         private MediaManager manager;
         private SystemMediaTransportControls controls;

--- a/windows/RNTrackPlayer/Logic/Track.cs
+++ b/windows/RNTrackPlayer/Logic/Track.cs
@@ -22,14 +22,20 @@ namespace TrackPlayer.Logic
             Id = (string)data.GetValue("id");
             Url = Utils.GetUri(data, "url", null);
             Type = Utils.GetValue<string>(data, "type", TrackType.Default);
+
+            SetMetadata(data);
+
+            _originalObj = data;
+        }
+
+        public void SetMetadata(JObject data)
+        {
             Duration = Utils.GetValue<double>(data, "duration", 0);
 
             Title = Utils.GetValue<string>(data, "title", null);
             Artist = Utils.GetValue<string>(data, "artist", null);
             Album = Utils.GetValue<string>(data, "album", null);
             Artwork = Utils.GetUri(data, "artwork", null);
-
-            _originalObj = data;
         }
 
         public JObject ToObject()

--- a/windows/RNTrackPlayer/Logic/Track.cs
+++ b/windows/RNTrackPlayer/Logic/Track.cs
@@ -36,6 +36,9 @@ namespace TrackPlayer.Logic
             Artist = Utils.GetValue<string>(data, "artist", null);
             Album = Utils.GetValue<string>(data, "album", null);
             Artwork = Utils.GetUri(data, "artwork", null);
+
+            if (_originalObj != null && _originalObj != data)
+                _originalObj.Merge(data);
         }
 
         public JObject ToObject()

--- a/windows/RNTrackPlayer/Players/Playback.cs
+++ b/windows/RNTrackPlayer/Players/Playback.cs
@@ -120,6 +120,14 @@ namespace TrackPlayer.Players
             promise?.Resolve(null);
         }
 
+        public void UpdateTrack(int index, Track track)
+        {
+            queue[index] = track;
+
+            if (index == currentTrack)
+                manager.GetMetadata().UpdateMetadata(track);
+        }
+
         public abstract SystemMediaTransportControls GetTransportControls();
 
         protected abstract void Load(Track track, IPromise promise);

--- a/windows/RNTrackPlayer/RNTrackPlayer.nuget.props
+++ b/windows/RNTrackPlayer/RNTrackPlayer.nuget.props
@@ -3,11 +3,11 @@
   <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
     <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
     <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
-    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">C:\Android\react-native-track-player\windows\RNTrackPlayer\project.lock.json</ProjectAssetsFile>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">C:\Git\rn\rntp\windows\RNTrackPlayer\project.lock.json</ProjectAssetsFile>
     <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
-    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\Guichaguri\.nuget\packages\</NuGetPackageFolders>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\g.oliveira\.nuget\packages\</NuGetPackageFolders>
     <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">ProjectJson</NuGetProjectStyle>
-    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">4.8.1</NuGetToolVersion>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">4.9.3</NuGetToolVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -18,4 +18,11 @@
     <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.7.0\build\Microsoft.Net.Native.SharedLibrary-arm.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.7.0\build\Microsoft.Net.Native.SharedLibrary-arm.props')" />
     <Import Project="$(NuGetPackageRoot)microsoft.net.native.compiler\1.7.3\build\Microsoft.Net.Native.Compiler.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.compiler\1.7.3\build\Microsoft.Net.Native.Compiler.props')" />
   </ImportGroup>
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <PkgMicrosoft_Net_Native_SharedLibrary-x86 Condition=" '$(PkgMicrosoft_Net_Native_SharedLibrary-x86)' == '' ">C:\Users\g.oliveira\.nuget\packages\microsoft.net.native.sharedlibrary-x86\1.7.0</PkgMicrosoft_Net_Native_SharedLibrary-x86>
+    <PkgMicrosoft_Net_Native_SharedLibrary-x64 Condition=" '$(PkgMicrosoft_Net_Native_SharedLibrary-x64)' == '' ">C:\Users\g.oliveira\.nuget\packages\microsoft.net.native.sharedlibrary-x64\1.7.0</PkgMicrosoft_Net_Native_SharedLibrary-x64>
+    <PkgMicrosoft_Net_Native_SharedLibrary-arm Condition=" '$(PkgMicrosoft_Net_Native_SharedLibrary-arm)' == '' ">C:\Users\g.oliveira\.nuget\packages\microsoft.net.native.sharedlibrary-arm\1.7.0</PkgMicrosoft_Net_Native_SharedLibrary-arm>
+    <PkgMicrosoft_Net_Native_Compiler Condition=" '$(PkgMicrosoft_Net_Native_Compiler)' == '' ">C:\Users\g.oliveira\.nuget\packages\microsoft.net.native.compiler\1.7.3</PkgMicrosoft_Net_Native_Compiler>
+    <PkgNewtonsoft_Json Condition=" '$(PkgNewtonsoft_Json)' == '' ">C:\Users\g.oliveira\.nuget\packages\newtonsoft.json\10.0.3</PkgNewtonsoft_Json>
+  </PropertyGroup>
 </Project>

--- a/windows/RNTrackPlayer/TrackPlayerModule.cs
+++ b/windows/RNTrackPlayer/TrackPlayerModule.cs
@@ -131,6 +131,28 @@ namespace TrackPlayer
         }
 
         [ReactMethod]
+        public void updateMetadata(string id, JObject metadata, IPromise promise)
+        {
+            var player = manager?.GetPlayer();
+            if (Utils.CheckPlayback(player, promise)) return;
+
+            var queue = player.GetQueue();
+            var index = queue.FindIndex(t => t.Id == id);
+
+            if (index == -1)
+            {
+                promise.Reject("track_not_in_queue", "Track not found");
+            }
+            else
+            {
+                var track = queue[index];
+                track.SetMetadata(metadata);
+                player.UpdateTrack(index, track);
+                promise.Resolve(null);
+            }
+        }
+
+        [ReactMethod]
         public void removeUpcomingTracks(IPromise promise)
         {
             var player = manager?.GetPlayer();

--- a/windows/RNTrackPlayer/TrackPlayerModule.cs
+++ b/windows/RNTrackPlayer/TrackPlayerModule.cs
@@ -131,7 +131,7 @@ namespace TrackPlayer
         }
 
         [ReactMethod]
-        public void updateMetadata(string id, JObject metadata, IPromise promise)
+        public void updateMetadataForTrack(string id, JObject metadata, IPromise promise)
         {
             var player = manager?.GetPlayer();
             if (Utils.CheckPlayback(player, promise)) return;


### PR DESCRIPTION
This PR adds the `updateMetadata(id, metadata)` function which allows you to update any track in the queue, including the current one. It returns a promise which resolves after the metadata has been successfully updated.

This PR supersedes #331 and implements #93. It is also the base requirement for #384.

#### Parameters
* `id`: The track id to update
* `metadata`: A subset of the track object containing only the `artwork`, `title`, `artist`, `album`, `description`, `genre`, `date`, `rating` and `duration` properties.

#### Rejections
As the function returns a promise, it can reject with the code `track_not_in_queue` when there's no track that matches the id.