### PR TITLE
[iOS] allow configuring the category for the shared AVAudioSession instance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,7 @@ declare namespace RNTrackPlayer {
     maxBuffer?: number;
     playBuffer?: number;
     maxCacheSize?: number;
+    iosCategory?: 'playback' | 'playAndRecord' | 'multiRoute';
   }
 
   export interface MetadataOptions {

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -131,13 +131,21 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
     @objc(setupPlayer:resolver:rejecter:)
     public func setupPlayer(config: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+            let categoryOption: String = config["iosCategory"] as? String ?? "playback"
+            let category: AVAudioSession.Category
+            if categoryOption.isEqual("playAndRecord") {
+                category = .playAndRecord
+            } else if categoryOption.isEqual("multiRoute") {
+                category = .multiRoute
+            } else {
+                category = .playback
+            }
+            try AVAudioSession.sharedInstance().setCategory(category, mode: .default)
             try AVAudioSession.sharedInstance().setActive(true)
+            resolve(NSNull())
         } catch {
             reject("setup_audio_session_failed", "Failed to setup audio session", error)
         }
-        
-        resolve(NSNull())
     }
     
     @objc(destroy)


### PR DESCRIPTION
I'm new to swift so I could have overlooked something or gotten the syntax wrong, but trying to make this change as painless as possible. It shouldn't affect any existing code, and seems to work for my purposes. I considered adding options for `mode` and `options` too, but thought I'd keep it simple. I'm using it like this:

```js
TrackPlayer.setupPlayer({ iosCategory: 'playAndRecord' }).then(...
```

I'd also be willing to add this option to the wiki if this is approved.

**Edit:** I've only added the categories that include playback (i.e. ones that should work with RNTP).

- I also noticed while testing that `resolve` was getting called even after `reject` was called, which was throwing its own error.

Fixes gh-469