### PR TITLE
[iOS] Move audio session category setting to `play()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,9 +69,9 @@ declare namespace RNTrackPlayer {
     maxBuffer?: number;
     playBuffer?: number;
     maxCacheSize?: number;
-    iosCategory?: 'playback'|'playAndRecord'|'multiRoute'|'ambient'|'soloAmbient'|'record';
-    iosCategoryOptions?: 'mixWithOthers'|'duckOthers'|'interruptSpokenAudioAndMixWithOthers'|'allowBluetooth'|'allowBluetoothA2DP'|'allowAirPlay'|'defaultToSpeaker';
-    iosCategoryMode?: 'default'|'gameChat'|'measurement'|'moviePlayback'|'spokenAudio'|'videoChat'|'videoRecording'|'voiceChat'|'voicePrompt';
+    iosCategory?: 'playback' | 'playAndRecord' | 'multiRoute' | 'ambient' | 'soloAmbient' | 'record';
+    iosCategoryOptions?: 'mixWithOthers' | 'duckOthers' | 'interruptSpokenAudioAndMixWithOthers' | 'allowBluetooth' | 'allowBluetoothA2DP' | 'allowAirPlay' | 'defaultToSpeaker';
+    iosCategoryMode?: 'default' | 'gameChat' | 'measurement' | 'moviePlayback' | 'spokenAudio' | 'videoChat' | 'videoRecording' | 'voiceChat' | 'voicePrompt';
   }
 
   export interface MetadataOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,7 @@ declare namespace RNTrackPlayer {
     maxBuffer?: number;
     playBuffer?: number;
     maxCacheSize?: number;
+    iosCategory?: 'playback' | 'playAndRecord' | 'multiRoute';
   }
 
   export interface MetadataOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,9 @@ declare namespace RNTrackPlayer {
     maxBuffer?: number;
     playBuffer?: number;
     maxCacheSize?: number;
-    iosCategory?: 'playback' | 'playAndRecord' | 'multiRoute';
+    iosCategory?: 'playback'|'playAndRecord'|'multiRoute'|'ambient'|'soloAmbient'|'record';
+    iosCategoryOptions?: 'mixWithOthers'|'duckOthers'|'interruptSpokenAudioAndMixWithOthers'|'allowBluetooth'|'allowBluetoothA2DP'|'allowAirPlay'|'defaultToSpeaker';
+    iosCategoryMode?: 'default'|'gameChat'|'measurement'|'moviePlayback'|'spokenAudio'|'videoChat'|'videoRecording'|'voiceChat'|'voicePrompt';
   }
 
   export interface MetadataOptions {

--- a/ios/RNTrackPlayer/Models/SessionCategories.swift
+++ b/ios/RNTrackPlayer/Models/SessionCategories.swift
@@ -1,0 +1,89 @@
+//
+//  SessionCategory.swift
+//  RNTrackPlayer
+//
+//  Created by Thomas Hessler on 3/12/19.
+//  Copyright © 2019 David Chavez. All rights reserved.
+//
+
+import Foundation
+import MediaPlayer
+import AVFoundation
+
+enum SessionCategory : String {
+    
+    case playAndRecord, multiRoute, playback, ambient, soloAmbient
+    
+    func mapConfigToAVAudioSessionCategory() -> AVAudioSession.Category {
+        switch self {
+        case .playAndRecord:
+            return .playAndRecord
+        case .multiRoute:
+            return .multiRoute
+        case .playback:
+            return .playback
+        case .ambient:
+            return .ambient
+        case .soloAmbient:
+            return .soloAmbient
+        }
+    }
+}
+
+enum SessionCategoryOptions : String {
+    
+    case mixWithOthers, duckOthers, interruptSpokenAudioAndMixWithOthers, allowBluetooth, allowBluetoothA2DP, allowAirPlay, defaultToSpeaker
+
+    func mapConfigToAVAudioSessionCategoryOptions() -> AVAudioSession.CategoryOptions? {
+        switch self {
+        case .mixWithOthers:
+            return .mixWithOthers
+        case .duckOthers:
+            return .duckOthers
+        case .interruptSpokenAudioAndMixWithOthers:
+            return .interruptSpokenAudioAndMixWithOthers
+        case .allowBluetooth:
+            return .allowBluetooth
+        case .allowBluetoothA2DP:
+            return .allowBluetoothA2DP
+        case .allowAirPlay:
+            return .allowAirPlay
+        case .defaultToSpeaker:
+            return .defaultToSpeaker
+        }
+    }
+}
+
+enum SessionCategoryMode : String {
+    
+    case `default`, gameChat, measurement, moviePlayback, spokenAudio, videoChat, videoRecording, voiceChat, voicePrompt
+    
+    func mapConfigToAVAudioSessionCategoryMode() -> AVAudioSession.Mode {
+        switch self {
+        case .default:
+            return .default
+        case .gameChat:
+            return .gameChat
+        case .measurement:
+            return .measurement
+        case .moviePlayback:
+            return .moviePlayback
+        case .spokenAudio:
+            return .spokenAudio
+        case .videoChat:
+            return .videoChat
+        case .videoRecording:
+            return .videoRecording
+        case .voiceChat:
+            return .voiceChat
+        case .voicePrompt:
+            if #available(iOS 12.0, *) {
+                return .voicePrompt
+            } else {
+                // Do Nothing
+                return .default
+            }
+        }
+    }
+}
+

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -133,73 +133,23 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
     
     @objc(setupPlayer:resolver:rejecter:)
     public func setupPlayer(config: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        
+
+        //configure base category -- defaults to .playback
         let sessionCategory: String = config["iosCategory"] as? String ?? "playback"
-        switch sessionCategory {
-            case "playAndRecord":
-                self.sessionCategory = .playAndRecord
-            case "multiRoute":
-                self.sessionCategory = .multiRoute
-            case "playback":
-                self.sessionCategory = .playback
-            case "ambient":
-                self.sessionCategory = .ambient
-            case "soloAmbient":
-                self.sessionCategory = .soloAmbient
-            default:
-                self.sessionCategory = .playback
-        }
+        self.sessionCategory = SessionCategory(rawValue: sessionCategory)!.mapConfigToAVAudioSessionCategory()
         
-        let sessionCategoryOpts: String = config["iosCategoryOptions"] as? String ?? ""
-        
-        switch sessionCategoryOpts {
-        case "mixWithOthers":
-            self.sessionCategoryOptions = .mixWithOthers
-        case "duckOthers":
-            self.sessionCategoryOptions = .duckOthers
-        case "interruptSpokenAudioAndMixWithOthers":
-            self.sessionCategoryOptions = .interruptSpokenAudioAndMixWithOthers
-        case "allowBluetooth":
-            self.sessionCategoryOptions = .allowBluetooth
-        case "allowBluetoothA2DP":
-            self.sessionCategoryOptions = .allowBluetoothA2DP
-        case "allowAirPlay":
-            self.sessionCategoryOptions = .allowAirPlay
-        case "defaultToSpeaker":
-            self.sessionCategoryOptions = .defaultToSpeaker
-        default:
-            //do nothing
+        //configure extra opts -- defaults to nil
+        let sessionCategoryOpts: String? = config["iosCategoryOptions"] as? String ?? nil
+        //this is because this doesnt default as anything
+        if(sessionCategoryOpts != nil) {
+            self.sessionCategoryOptions = SessionCategoryOptions(rawValue: sessionCategoryOpts!)!.mapConfigToAVAudioSessionCategoryOptions()
+        } else {
             self.sessionCategoryOptions = nil
         }
-        
+
+        //configure mode -- defaults to .default
         let sessionCategoryMode: String = config["iosCategoryMode"] as? String ?? "default"
-        
-        switch sessionCategoryMode {
-        case "default":
-            self.sessionCategoryMode = .default
-        case "gameChat":
-            self.sessionCategoryMode = .gameChat
-        case "measurement":
-            self.sessionCategoryMode = .measurement
-        case "moviePlayback":
-            self.sessionCategoryMode = .moviePlayback
-        case "spokenAudio":
-            self.sessionCategoryMode = .spokenAudio
-        case "videoChat":
-            self.sessionCategoryMode = .videoChat
-        case "videoRecording":
-            self.sessionCategoryMode = .videoRecording
-        case "voiceChat":
-            self.sessionCategoryMode = .voiceChat
-        case "voicePrompt":
-            if #available(iOS 12.0, *) {
-                self.sessionCategoryMode = .voicePrompt
-            } else {
-                // Do Nothing
-            }
-        default:
-            self.sessionCategoryMode = .default
-        }
+        self.sessionCategoryMode = SessionCategoryMode(rawValue: sessionCategoryMode)!.mapConfigToAVAudioSessionCategoryMode()
         
         resolve(NSNull())
     }

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -130,13 +130,6 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
     
     @objc(setupPlayer:resolver:rejecter:)
     public func setupPlayer(config: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-            try AVAudioSession.sharedInstance().setActive(true)
-        } catch {
-            reject("setup_audio_session_failed", "Failed to setup audio session", error)
-        }
-        
         resolve(NSNull())
     }
     
@@ -346,6 +339,12 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
     @objc(play:rejecter:)
     public func play(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Starting/Resuming playback")
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            reject("setup_audio_session_failed", "Failed to setup audio session", error)
+        }
         try? player.play()
         resolve(NSNull())
     }

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -136,18 +136,18 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
 
         //configure base category -- defaults to .playback
         if let sessionCategory = config["iosCategory"] as? String {
-          let mappedCategory = SessionCategory(rawValue: sessionCategory)
-          self.sessionCategory = (mappedCategory ?? .playback).mapConfigToAVAudioSessionCategory()
+            let mappedCategory = SessionCategory(rawValue: sessionCategory)
+            self.sessionCategory = (mappedCategory ?? .playback).mapConfigToAVAudioSessionCategory()
         }
         
         if let sessionCategoryOpts = config["iosCategoryOptions"] as? String, let mappedCategoryOptions = SessionCategoryOptions(rawValue: sessionCategoryOpts) {
-          self.sessionCategoryOptions = mappedCategory.mapConfigToAVAudioSessionCategoryOptions()
+            self.sessionCategoryOptions = mappedCategoryOptions.mapConfigToAVAudioSessionCategoryOptions()!
         }
-
+        
         //configure mode -- defaults to .default
         if let sessionCategoryMode = config["iosCategoryMode"] as? String {
-          let mappedCategoryMode = SessionCategoryMode(rawValue: sessionCategory)
-          self.sessionCategoryMode = (mappedCategoryMode ?? .default).mapConfigToAVAudioSessionCategoryMode()
+            let mappedCategoryMode = SessionCategoryMode(rawValue: sessionCategoryMode)
+            self.sessionCategoryMode = (mappedCategoryMode ?? .default).mapConfigToAVAudioSessionCategoryMode()
         }
         
         resolve(NSNull())

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -21,7 +21,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
         return player
     }()
     
-    private var sessionCategory: AVAudioSession.Category
+    private var sessionCategory: AVAudioSession.Category = .playback
     
     // MARK: - AudioPlayerDelegate
     

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -22,7 +22,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
     }()
     
     private var sessionCategory: AVAudioSession.Category = .playback
-    private var sessionCategoryOptions: AVAudioSession.CategoryOptions = []
+    private var sessionCategoryOptions: AVAudioSession.CategoryOptions? = []
     private var sessionCategoryMode: AVAudioSession.Mode = .default
     
     // MARK: - AudioPlayerDelegate

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -22,7 +22,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
     }()
     
     private var sessionCategory: AVAudioSession.Category = .playback
-    private var sessionCategoryOptions: AVAudioSession.CategoryOptions? = []
+    private var sessionCategoryOptions: AVAudioSession.CategoryOptions = []
     private var sessionCategoryMode: AVAudioSession.Mode = .default
     
     // MARK: - AudioPlayerDelegate

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -146,8 +146,8 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
 
         //configure mode -- defaults to .default
         if let sessionCategoryMode = config["iosCategoryMode"] as? String {
-          let mappedCategoryMode = SessionCategory(rawValue: sessionCategory)
-          self.sessionCategoryMode = (mappedCategoryMode ?? .default).mapConfigToAVAudioSessionCategory()
+          let mappedCategoryMode = SessionCategoryMode(rawValue: sessionCategory)
+          self.sessionCategoryMode = (mappedCategoryMode ?? .default).mapConfigToAVAudioSessionCategoryMode()
         }
         
         resolve(NSNull())

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -21,7 +21,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
         return player
     }()
     
-    private var sessionCategory: AVAudioSession.Category?
+    private var sessionCategory: AVAudioSession.Category
     
     // MARK: - AudioPlayerDelegate
     
@@ -349,14 +349,8 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
     public func play(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Starting/Resuming playback")
         //do this here so we can have bg audio until we play
-        let category : AVAudioSession.Category
-        if(sessionCategory != nil){
-            category = sessionCategory!
-        } else {
-            category = .playback
-        }
         try? AVAudioSession.sharedInstance().setActive(false)
-        try? AVAudioSession.sharedInstance().setCategory(category, mode: .default)
+        try? AVAudioSession.sharedInstance().setCategory(self.sessionCategory, mode: .default)
         try? AVAudioSession.sharedInstance().setActive(true)
         try? player.play()
         resolve(NSNull())


### PR DESCRIPTION
When the audio session is created on the `setupPlayer()` method, entering the application causes current background music to end. This will set the category on `play()` and end the background audio only when necessary