### PR TITLE
[iOS] Clear nowplayinginfocenter on `reset()`

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -350,8 +350,8 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
         resolve(NSNull())
         //tell app to stop receiving remote control events
         //so the MPNowPlayingInfoCenter clears properly
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            UIApplication.shared.beginReceivingRemoteControlEvents();
+        DispatchQueue.main.async {
+            UIApplication.shared.endReceivingRemoteControlEvents();
         }
     }
     

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -224,6 +224,13 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
     
     @objc(add:before:resolver:rejecter:)
     public func add(trackDicts: [[String: Any]], before trackId: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        
+        //tell app to receive remote control events on add
+        //so we can remove it on remove
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            UIApplication.shared.beginReceivingRemoteControlEvents();
+        }
+
         var tracks = [Track]()
         for trackDict in trackDicts {
             guard let track = Track(dictionary: trackDict) else {
@@ -341,6 +348,11 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
         print("Resetting player.")
         player.stop()
         resolve(NSNull())
+        //tell app to stop receiving remote control events
+        //so the MPNowPlayingInfoCenter clears properly
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            UIApplication.shared.beginReceivingRemoteControlEvents();
+        }
     }
     
     @objc(play:rejecter:)

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -223,10 +223,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
     }
     
     @objc(add:before:resolver:rejecter:)
-    public func add(trackDicts: [[String: Any]], before trackId: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        
-        //tell app to receive remote control events on add
-        //so we can remove it on remove
+    public func add(trackDicts: [[String: Any]], before trackId: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {        
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             UIApplication.shared.beginReceivingRemoteControlEvents();
         }
@@ -348,8 +345,6 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
         print("Resetting player.")
         player.stop()
         resolve(NSNull())
-        //tell app to stop receiving remote control events
-        //so the MPNowPlayingInfoCenter clears properly
         DispatchQueue.main.async {
             UIApplication.shared.endReceivingRemoteControlEvents();
         }


### PR DESCRIPTION
When you call `reset()` the track does not get removed from the `MPNowPlayingInfoCenter` delegate. If we call the `UIApplication.shared`'s method `beginReceivingRemoteControlEvents` we can instantiate it when someone adds a track. This is delayed by 500ms so that the UI thread is not blocked when attempting to do the rest of the functionality of adding tracks. By setting it to being able to receive them, we can then execute `endReceivingRemoteControlEvents` on `reset()` and clear the `MPNowPlayingInfoCenter` properly