### PR TITLE
[iOS] Fix build when linked using pods

### DIFF
--- a/react-native-track-player.podspec
+++ b/react-native-track-player.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author       = "David Chavez"
   s.homepage     = "https://github.com/react-native-kit/react-native-track-player"
   s.license      = "Apache-2.0"
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "10.0"
   s.source       = { :git => "https://github.com/react-native-kit/react-native-track-player.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,swift}"
   s.dependency "React"


### PR DESCRIPTION
These errors were only seen if react-native-track-player was linked using pods. Since RNTP uses a bunch of stuff that is only available in iOS 10 or newer, and since the podspec platform setting is iOS 9, it cannot compile (even when the parent project deployment target/swift settings are set to higher versions). Changing this to 10 fixes the issue.

![Screenshot 2019-03-11 12 21 03](https://user-images.githubusercontent.com/192451/54139804-b9394780-43f8-11e9-864d-e7a0a43155d9.png)
