### PR TITLE
[iOS] set automaticallyWaitsToMinimizeStalling to true for more resilient buffering

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -16,7 +16,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
         
         player.delegate = self
         player.bufferDuration = 1
-        player.automaticallyWaitsToMinimizeStalling = false
+        player.automaticallyWaitsToMinimizeStalling = true
         
         return player
     }()


### PR DESCRIPTION
We've been having issues with buffering where it would often start playing before it had enough to play. Simply setting this to `true` fixes all our problems. I *think* it's safe to set this to `true` whether it's a local file or not.