### PR TITLE
Buffering state before song is ready to play

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -177,7 +177,7 @@ public abstract class ExoPlayback<T extends Player> implements EventListener {
     public int getState() {
         switch(player.getPlaybackState()) {
             case Player.STATE_BUFFERING:
-                return player.getPlayWhenReady() ? PlaybackStateCompat.STATE_BUFFERING : PlaybackStateCompat.STATE_PAUSED;
+                return PlaybackStateCompat.STATE_BUFFERING;
             case Player.STATE_ENDED:
                 return PlaybackStateCompat.STATE_STOPPED;
             case Player.STATE_IDLE:


### PR DESCRIPTION
When a song is tapped to play in IOS, the state changes from stop to buffering and then changes to play. It doesn't happened on Android.