### PR TITLE
[iOS] Allow multiple category options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,8 +70,8 @@ declare namespace RNTrackPlayer {
     playBuffer?: number;
     maxCacheSize?: number;
     iosCategory?: 'playback' | 'playAndRecord' | 'multiRoute' | 'ambient' | 'soloAmbient' | 'record';
-    iosCategoryOptions?: 'mixWithOthers' | 'duckOthers' | 'interruptSpokenAudioAndMixWithOthers' | 'allowBluetooth' | 'allowBluetoothA2DP' | 'allowAirPlay' | 'defaultToSpeaker';
     iosCategoryMode?: 'default' | 'gameChat' | 'measurement' | 'moviePlayback' | 'spokenAudio' | 'videoChat' | 'videoRecording' | 'voiceChat' | 'voicePrompt';
+    iosCategoryOptions?: Array<'mixWithOthers' | 'duckOthers' | 'interruptSpokenAudioAndMixWithOthers' | 'allowBluetooth' | 'allowBluetoothA2DP' | 'allowAirPlay' | 'defaultToSpeaker'>;
   }
 
   export interface MetadataOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,7 @@ declare namespace RNTrackPlayer {
     iosCategory?: 'playback' | 'playAndRecord' | 'multiRoute' | 'ambient' | 'soloAmbient' | 'record';
     iosCategoryMode?: 'default' | 'gameChat' | 'measurement' | 'moviePlayback' | 'spokenAudio' | 'videoChat' | 'videoRecording' | 'voiceChat' | 'voicePrompt';
     iosCategoryOptions?: Array<'mixWithOthers' | 'duckOthers' | 'interruptSpokenAudioAndMixWithOthers' | 'allowBluetooth' | 'allowBluetoothA2DP' | 'allowAirPlay' | 'defaultToSpeaker'>;
+    waitForBuffer?: boolean;
   }
 
   export interface MetadataOptions {

--- a/ios/RNTrackPlayer.xcodeproj/project.pbxproj
+++ b/ios/RNTrackPlayer.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		9B78A2461F3F12BC002B5E3C /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B78A2451F3F12BC002B5E3C /* Track.swift */; };
 		9B78A2481F3F12C9002B5E3C /* MediaURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B78A2471F3F12C9002B5E3C /* MediaURL.swift */; };
 		9BFC1FDD1F61A8E8008795BF /* Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFC1FDC1F61A8E8008795BF /* Capabilities.swift */; };
+		F45B42662246C013005A87D9 /* SessionCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45B42652246C013005A87D9 /* SessionCategories.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -81,6 +82,7 @@
 		9B78A2471F3F12C9002B5E3C /* MediaURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaURL.swift; sourceTree = "<group>"; };
 		9BFBA4D01F3DFA3F00453D3A /* RNTrackPlayer-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNTrackPlayer-Bridging-Header.h"; sourceTree = "<group>"; };
 		9BFC1FDC1F61A8E8008795BF /* Capabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capabilities.swift; sourceTree = "<group>"; };
+		F45B42652246C013005A87D9 /* SessionCategories.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionCategories.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,6 +138,7 @@
 			children = (
 				9B78A2451F3F12BC002B5E3C /* Track.swift */,
 				9B78A2471F3F12C9002B5E3C /* MediaURL.swift */,
+				F45B42652246C013005A87D9 /* SessionCategories.swift */,
 				9BFC1FDC1F61A8E8008795BF /* Capabilities.swift */,
 				9A0CF10D2046E5AC0093A5DF /* PitchAlgorithms.swift */,
 			);
@@ -279,6 +282,7 @@
 				9B40782621F34CC800F61AA2 /* NowPlayingInfoController.swift in Sources */,
 				9B40782121F34CC800F61AA2 /* AVPlayerWrapperProtocol.swift in Sources */,
 				9B40782021F34CC800F61AA2 /* AVPlayerWrapperState.swift in Sources */,
+				F45B42662246C013005A87D9 /* SessionCategories.swift in Sources */,
 				9B78A2481F3F12C9002B5E3C /* MediaURL.swift in Sources */,
 				9B40781721F34CC800F61AA2 /* AudioSession.swift in Sources */,
 				9B40781F21F34CC800F61AA2 /* QueueManager.swift in Sources */,

--- a/ios/RNTrackPlayer.xcodeproj/project.pbxproj
+++ b/ios/RNTrackPlayer.xcodeproj/project.pbxproj
@@ -40,7 +40,6 @@
 		9B78A2461F3F12BC002B5E3C /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B78A2451F3F12BC002B5E3C /* Track.swift */; };
 		9B78A2481F3F12C9002B5E3C /* MediaURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B78A2471F3F12C9002B5E3C /* MediaURL.swift */; };
 		9BFC1FDD1F61A8E8008795BF /* Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFC1FDC1F61A8E8008795BF /* Capabilities.swift */; };
-		F45B42662246C013005A87D9 /* SessionCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45B42652246C013005A87D9 /* SessionCategories.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -92,7 +91,6 @@
 		9B78A2471F3F12C9002B5E3C /* MediaURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaURL.swift; sourceTree = "<group>"; };
 		9BFBA4D01F3DFA3F00453D3A /* RNTrackPlayer-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNTrackPlayer-Bridging-Header.h"; sourceTree = "<group>"; };
 		9BFC1FDC1F61A8E8008795BF /* Capabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capabilities.swift; sourceTree = "<group>"; };
-		F45B42652246C013005A87D9 /* SessionCategories.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionCategories.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,7 +149,6 @@
 				F45B42652246C013005A87D9 /* SessionCategories.swift */,
 				9BFC1FDC1F61A8E8008795BF /* Capabilities.swift */,
 				9A0CF10D2046E5AC0093A5DF /* PitchAlgorithms.swift */,
-				9B18C2F9226356560019375A /* SessionCategories.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";

--- a/ios/RNTrackPlayer.xcodeproj/project.pbxproj
+++ b/ios/RNTrackPlayer.xcodeproj/project.pbxproj
@@ -146,9 +146,9 @@
 			children = (
 				9B78A2451F3F12BC002B5E3C /* Track.swift */,
 				9B78A2471F3F12C9002B5E3C /* MediaURL.swift */,
-				F45B42652246C013005A87D9 /* SessionCategories.swift */,
 				9BFC1FDC1F61A8E8008795BF /* Capabilities.swift */,
 				9A0CF10D2046E5AC0093A5DF /* PitchAlgorithms.swift */,
+				9B18C2F9226356560019375A /* SessionCategories.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -140,8 +140,9 @@ public class RNTrackPlayer: RCTEventEmitter, AudioPlayerDelegate {
             self.sessionCategory = (mappedCategory ?? .playback).mapConfigToAVAudioSessionCategory()
         }
         
-        if let sessionCategoryOpts = config["iosCategoryOptions"] as? String, let mappedCategoryOptions = SessionCategoryOptions(rawValue: sessionCategoryOpts) {
-            self.sessionCategoryOptions = mappedCategoryOptions.mapConfigToAVAudioSessionCategoryOptions()!
+        if let sessionCategoryOpts = config["iosCategoryOptions"] as? [String] {
+            let mappedCategoryOpts = sessionCategoryOpts.compactMap { SessionCategoryOptions(rawValue: $0)?.mapConfigToAVAudioSessionCategoryOptions() }
+            self.sessionCategoryOptions = AVAudioSession.CategoryOptions(mappedCategoryOpts)
         }
         
         //configure mode -- defaults to .default

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -106,10 +106,9 @@ public class RNTrackPlayer: RCTEventEmitter {
                 sessionCategory = mappedCategory.mapConfigToAVAudioSessionCategory()
         }
         
-        if let sessionCategoryOptsStr = config["iosCategoryOptions"] as? [String] {
-            let mappedCategoryOpts = sessionCategoryOpts.compactMap { SessionCategoryOptions(rawValue: $0)?.mapConfigToAVAudioSessionCategoryOptions() }
-            sessionCategoryOptions = AVAudioSession.CategoryOptions(mappedCategoryOpts)
-        }
+        let sessionCategoryOptsStr = config["iosCategoryOptions"] as? [String]
+        let mappedCategoryOpts = sessionCategoryOpts.compactMap { SessionCategoryOptions(rawValue: $0)?.mapConfigToAVAudioSessionCategoryOptions() }
+        sessionCategoryOptions = AVAudioSession.CategoryOptions(mappedCategoryOpts)
         
         if
             let sessionCategoryModeStr = config["iosCategoryMode"] as? String,
@@ -156,9 +155,8 @@ public class RNTrackPlayer: RCTEventEmitter {
     
     @objc(updateOptions:resolver:rejecter:)
     public func update(options: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        let castedCapabilities = options["capabilities"] as? [String]
-        let supportedCapabilities = castedCapabilities?.filter { Capability(rawValue: $0) != nil }
-        let capabilities = supportedCapabilities?.compactMap { Capability(rawValue: $0) } ?? []
+        let capabilitiesStr = options["capabilities"] as? [String]
+        let capabilities = capabilitiesStr?.compactMap { Capability(rawValue: $0) } ?? []
         
         let remoteCommands = capabilities.map { $0.mapToPlayerCommand(jumpInterval: options["jumpInterval"] as? NSNumber) }
         player.remoteCommands.removeAll()


### PR DESCRIPTION
`categoryOptions` is an OptionSet, which means it can set multiple at once. I think category options needs to be an array of strings. For instance, for my app, I'm going to want to set [.duckOthers, .allowBluetooth, .allowBluetoothA2DP, .allowAirPlay, .defaultToSpeaker].

I'm still new to Swift. There might be a better way to convert an array of strings to an OptionSet, but I'm currently using this PR in my app like so...

```js
  TrackPlayer.setupPlayer({
    iosCategory: 'playAndRecord',
    iosCategoryMode: 'default',
    iosCategoryOptions: [
      'duckOthers',
      'allowBluetooth',
      'allowBluetoothA2DP',
      'allowAirPlay',
      'defaultToSpeaker'
    ]
  })
```

Edit: my first pass wasn't actually setting the options. I didn't need to reduce, I just needed to pass the mapped options to the constructor.