### PR TITLE
Add support for Amazon devices using exoplayer-amazon-port 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,21 +27,21 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-	publishNonDefault true
+    publishNonDefault true
 
-	flavorDimensions "store"
-	productFlavors {
+    flavorDimensions "store"
+    productFlavors {
         google {
-			dimension "store"
-		}
+            dimension "store"
+        }
         amazon {
-			dimension "store"
-		}
+            dimension "store"
+        }
     }
 
-	buildTypes {
+    buildTypes {
         release {}
-	}
+    }
 
     compileSdkVersion safeExtGet("compileSdkVersion", 27)
 
@@ -81,12 +81,11 @@ repositories {
 // https://medium.com/@elye.project/support-flavors-and-buildtypes-across-library-modules-31acf9c6d806
 
 configurations {
-	google
-	amazon
+    google
+    amazon
 }
 
 dependencies {
-    
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -87,7 +87,7 @@ configurations {
 
 dependencies {
     
-	//noinspection GradleDynamicVersion
+    //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
     // ExoPlayer Core

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,22 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+	publishNonDefault true
+
+	flavorDimensions "store"
+	productFlavors {
+        google {
+			dimension "store"
+		}
+        amazon {
+			dimension "store"
+		}
+    }
+
+	buildTypes {
+        release {}
+	}
+
     compileSdkVersion safeExtGet("compileSdkVersion", 27)
 
     defaultConfig {
@@ -60,32 +76,49 @@ repositories {
     mavenCentral()
 }
 
+// Build variants get passed to this module,
+// so that it can use either google or amazon libraries.
+// https://medium.com/@elye.project/support-flavors-and-buildtypes-across-library-modules-31acf9c6d806
+
+configurations {
+	google
+	amazon
+}
+
 dependencies {
-    //noinspection GradleDynamicVersion
+    
+	//noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
     // ExoPlayer Core
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.9.2'
+    googleImplementation 'com.google.android.exoplayer:exoplayer-core:2.9.6'
+    amazonImplementation 'com.amazon.android:exoplayer-core:2.9.6'
 
     // ExoPlayer DASH
     if (dash) {
-        implementation 'com.google.android.exoplayer:exoplayer-dash:2.9.2'
+        googleImplementation 'com.google.android.exoplayer:exoplayer-dash:2.9.6'
+        amazonImplementation 'com.amazon.android:exoplayer-dash:2.9.6'
     } else {
-        compileOnly 'com.google.android.exoplayer:exoplayer-dash:2.9.2'
+        googleCompileOnly 'com.google.android.exoplayer:exoplayer-dash:2.9.6'
+        amazonCompileOnly 'com.amazon.android:exoplayer-dash:2.9.6'
     }
 
     // ExoPlayer HLS
     if (hls) {
-        implementation 'com.google.android.exoplayer:exoplayer-hls:2.9.2'
+        googleImplementation 'com.google.android.exoplayer:exoplayer-hls:2.9.6'
+        amazonImplementation 'com.amazon.android:exoplayer-hls:2.9.6'
     } else {
-        compileOnly 'com.google.android.exoplayer:exoplayer-hls:2.9.2'
+        googleCompileOnly 'com.google.android.exoplayer:exoplayer-hls:2.9.6'
+        amazonCompileOnly 'com.amazon.android:exoplayer-hls:2.9.6'
     }
 
     // ExoPlayer SmoothStreaming
     if (smoothstreaming) {
-        implementation 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.9.2'
+        googleImplementation 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.9.6'
+        amazonImplementation 'com.amazon.android:exoplayer-smoothstreaming:2.9.6'
     } else {
-        compileOnly 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.9.2'
+        googleCompileOnly 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.9.6'
+        amazonCompileOnly 'com.amazon.android:exoplayer-smoothstreaming:2.9.6'
     }
 
     // Make sure we're using at least the support library 27.1.1

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
@@ -71,7 +71,7 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
     @Override
     public void add(Track track, int index, Promise promise) {
         queue.add(index, track);
-		source.addMediaSource(index, track.toMediaSource(context, this), new Handler(), Utils.toRunnable(promise));
+        source.addMediaSource(index, track.toMediaSource(context, this), new Handler(), Utils.toRunnable(promise));
 
         prepare();
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
@@ -1,5 +1,6 @@
 package com.guichaguri.trackplayer.service.player;
 
+import android.os.Handler;
 import android.content.Context;
 import android.util.Log;
 import com.facebook.react.bridge.Promise;
@@ -70,7 +71,7 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
     @Override
     public void add(Track track, int index, Promise promise) {
         queue.add(index, track);
-        source.addMediaSource(index, track.toMediaSource(context, this), Utils.toRunnable(promise));
+		source.addMediaSource(index, track.toMediaSource(context, this), new Handler(), Utils.toRunnable(promise));
 
         prepare();
     }
@@ -84,7 +85,7 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
         }
 
         queue.addAll(index, tracks);
-        source.addMediaSources(index, trackList, Utils.toRunnable(promise));
+        source.addMediaSources(index, trackList, new Handler(), Utils.toRunnable(promise));
 
         prepare();
     }
@@ -109,9 +110,9 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
             queue.remove(index);
 
             if(i == 0) {
-                source.removeMediaSource(index, Utils.toRunnable(promise));
+                source.removeMediaSource(index, new Handler(), Utils.toRunnable(promise));
             } else {
-                source.removeMediaSource(index, null);
+                source.removeMediaSource(index, null, null);
             }
         }
     }
@@ -123,7 +124,7 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
 
         for (int i = queue.size() - 1; i > currentIndex; i--) {
             queue.remove(i);
-            source.removeMediaSource(i, null);
+            source.removeMediaSource(i, null, null);
         }
     }
 


### PR DESCRIPTION
ExoPlayer does not fully support Amazon's Fire OS fork of Android.

Amazon provides a ported version of ExoPlayer.
https://developer.amazon.com/docs/fire-tv/media-players.html#exoplayer
https://github.com/amzn/exoplayer-amazon-port

This is how I configured my project to include the appropriate version of ExoPlayer depending on platform.