### PR TITLE
Added warning that Expo is not supported.

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -3,9 +3,6 @@ title: Installation
 permalink: /install/
 ---
 
-## Warning
-**Currently react-native-track-player does not support projects with Expo or Expokit.**
-
 ## Installing the packages
 **1. Install the module from npm or yarn**
 ```
@@ -137,6 +134,9 @@ To update it, run the same command again.
 Note: You don't need to link the module after updating it.
 
 ## Troubleshooting
+
+#### Expo and Expokit support
+Currently react-native-track-player does not support projects with Expo or Expokit.
 
 #### iOS: (Enable Swift) `library not found for -lswiftCoreAudio for architecture x86_64`
 Because the iOS module uses Swift, if the user is using a standard react-native application they'll need to add support for Swift in the project. This can be easily by adding a swift file to the Xcode project -- could be called `dummy.swift` and saying yes when prompted if you'd like to generate a bridging header.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -3,6 +3,9 @@ title: Installation
 permalink: /install/
 ---
 
+## Warning
+**Currently react-native-track-player does not support projects with Expo or Expokit.**
+
 ## Installing the packages
 **1. Install the module from npm or yarn**
 ```


### PR DESCRIPTION
I've just started my experience with React Native and was really confused - Quickstart page for RN suggests using Expo as recommended way to create new projects:

https://facebook.github.io/react-native/docs/getting-started

I've tried both managed and ejected Expo project and bare project, though neither of them seems to be compatible with `react-native-track-player`. Finally with plain `react-native init` we made it, but till that moment it was very frustrating.

Considering that Expo is suggested in official docs and this package currently has no support for it I propose to declare it in Installation page of docs so people could save time searching project issues on random build exceptions on both platforms.