### PR TITLE
Added an event that triggers when metadata is received from the track source

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -218,7 +218,7 @@ public class MusicManager implements OnAudioFocusChangeListener {
     }
 
     public void onMetadataReceived(String source, String title, String url, String artist, String album, String date, String genre) {
-        Log.d(Utils.LOG, "onMetadataReceived");
+        Log.d(Utils.LOG, "onMetadataReceived: " + source);
 
         Bundle bundle = new Bundle();
         bundle.putString("source", source);

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -217,6 +217,20 @@ public class MusicManager implements OnAudioFocusChangeListener {
         service.emit(MusicEvents.PLAYBACK_QUEUE_ENDED, bundle);
     }
 
+    public void onMetadataReceived(String source, String title, String url, String artist, String album, String date, String genre) {
+        Log.d(Utils.LOG, "onMetadataReceived");
+
+        Bundle bundle = new Bundle();
+        bundle.putString("source", source);
+        bundle.putString("title", title);
+        bundle.putString("url", url);
+        bundle.putString("artist", artist);
+        bundle.putString("album", album);
+        bundle.putString("date", date);
+        bundle.putString("genre", genre);
+        service.emit(MusicEvents.PLAYBACK_METADATA, bundle);
+    }
+
     public void onError(String code, String error) {
         Log.d(Utils.LOG, "onError");
         Log.e(Utils.LOG, "Playback error: " + code + " - " + error);

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -13,6 +13,7 @@ import com.google.android.exoplayer2.metadata.icy.IcyHeaders;
 import com.google.android.exoplayer2.metadata.icy.IcyInfo;
 import com.google.android.exoplayer2.metadata.id3.TextInformationFrame;
 import com.google.android.exoplayer2.metadata.id3.UrlLinkFrame;
+import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.guichaguri.trackplayer.service.MusicManager;
@@ -240,7 +241,21 @@ public abstract class ExoPlayback<T extends Player> implements EventListener, Me
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
+        for(int i = 0; i < trackGroups.length; i++) {
+            // Loop through all track groups.
+            // As for the current implementation, there should be only one
+            TrackGroup group = trackGroups.get(i);
 
+            for(int f = 0; f < group.length; f++) {
+                // Loop through all formats inside the track group
+                Format format = group.getFormat(f);
+
+                // Parse the metadata if it is present
+                if (format.metadata != null) {
+                    onMetadata(format.metadata);
+                }
+            }
+        }
     }
 
     @Override

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -423,6 +423,19 @@ Fired when the queue reaches the end.
 | track    | `string` | The previous track id. Might be null      |
 | position | `number` | The previous track position in seconds    |
 
+#### `playback-metadata-received`
+Fired when the current track receives metadata encoded in. (e.g. ID3 tags or Icy Metadata).
+
+| Param    | Type     | Description                                         |
+| -------- | -------- | --------------------------------------------------- |
+| source   | `string` | The metadata source (`id3`, `icy` or `icy-headers`) |
+| title    | `string` | The track title. Might be null                      |
+| url      | `string` | The track url. Might be null                        |
+| artist   | `string` | The track artist. Might be null                     |
+| album    | `string` | The track album. Might be null                      |
+| date     | `string` | The track date. Might be null                       |
+| genre    | `string` | The track genre. Might be null                      |
+
 #### `playback-error`
 Fired when an error occurs.
 


### PR DESCRIPTION
This PR adds the `playback-metadata-received` event, which is fired whenever ID3 Tags, Icy Metadata or Icy Headers are received with the following parameters:

| Param    | Type     | Description                                         |
| -------- | -------- | --------------------------------------------------- |
| source   | `string` | The metadata source (`id3`, `icy` or `icy-headers`) |
| title    | `string` | The track title. Might be null                      |
| url      | `string` | The track url. Might be null                        |
| artist   | `string` | The track artist. Might be null                     |
| album    | `string` | The track album. Might be null                      |
| date     | `string` | The track date. Might be null                       |
| genre    | `string` | The track genre. Might be null                      |

This PR closes #192, and supersedes #384

### Implementation Details
#### ID3 Tags
The parameters are filled from the following ID3 tags:

| Parameter | ID3 Tags |
| ------------ | ---------- |
| title | `TIT2` |
| album | `TALB` or `TOAL` |
| artist | `TOPE` |
| date | `TDRC` |
| url | `WOAS`, `WORS` or `WOAF` |

#### Icy Metadata
The parameters are filled from the following properties:

| Parameter | Property |
| ----------- | ---------- |
| title | `StreamTitle`¹ |
| artist | `StreamTitle`¹ |
| url | `StreamUrl` |

¹ - The module parses the `StreamTitle` string splitting the first " - ". The first part is set as the `artist` and the second part is set as `title`. When there is no occurrences, the whole string is set as `title`.

#### Icy Headers
The parameters are filled from the following headers:

| Parameter | Header |
| ----------- | -------- |
| title | `icy-name` |
| genre | `icy-genre` |
| url | `icy-url` |