### PR TITLE
[iOS] Fix blocking delay of adding tracks and resetting by loading tracks async

### DIFF
--- a/ios/RNTrackPlayer/Vendor/AudioPlayer/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/ios/RNTrackPlayer/Vendor/AudioPlayer/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -31,7 +31,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     let playerTimeObserver: AVPlayerTimeObserver
     let playerItemNotificationObserver: AVPlayerItemNotificationObserver
     let playerItemObserver: AVPlayerItemObserver
-
+    
     /**
      True if the last call to load(from:playWhenReady) had playWhenReady=true.
      */
@@ -75,6 +75,8 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         return avPlayer.currentItem
     }
     
+    var _pendingAsset: AVAsset? = nil
+    
     var automaticallyWaitsToMinimizeStalling: Bool {
         get { return avPlayer.automaticallyWaitsToMinimizeStalling }
         set { avPlayer.automaticallyWaitsToMinimizeStalling = newValue }
@@ -84,7 +86,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         let seconds = avPlayer.currentTime().seconds
         return seconds.isNaN ? 0 : seconds
     }
-
+    
     var duration: TimeInterval {
         if let seconds = currentItem?.asset.duration.seconds, !seconds.isNaN {
             return seconds
@@ -100,9 +102,9 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     }
     
     var bufferedPosition: TimeInterval {
-	return currentItem?.loadedTimeRanges.last?.timeRangeValue.end.seconds ?? 0
+        return currentItem?.loadedTimeRanges.last?.timeRangeValue.end.seconds ?? 0
     }
-
+    
     weak var delegate: AVPlayerWrapperDelegate? = nil
     
     var bufferDuration: TimeInterval = 0
@@ -112,7 +114,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
             playerTimeObserver.periodicObserverTimeInterval = timeEventFrequency.getTime()
         }
     }
-
+    
     var rate: Float {
         get { return avPlayer.rate }
         set { avPlayer.rate = newValue }
@@ -142,6 +144,8 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
             pause()
         case .paused:
             play()
+        @unknown default:
+            fatalError("Unknown AVPlayer.timeControlStatus")
         }
     }
     
@@ -161,22 +165,55 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
             self.delegate?.AVWrapper(seekTo: Int(seconds), didFinish: finished)
         }
     }
-
+    
     func load(from url: URL, playWhenReady: Bool) {
         reset(soft: true)
         _playWhenReady = playWhenReady
-
+        
         // Set item
-        let currentAsset = AVURLAsset(url: url)
-        let currentItem = AVPlayerItem(asset: currentAsset, automaticallyLoadedAssetKeys: [Constants.assetPlayableKey])
-        currentItem.preferredForwardBufferDuration = bufferDuration
-        avPlayer.replaceCurrentItem(with: currentItem)
-
-        // Register for events
-        playerTimeObserver.registerForBoundaryTimeEvents()
-        playerObserver.startObserving()
-        playerItemNotificationObserver.startObserving(item: currentItem)
-        playerItemObserver.startObserving(item: currentItem)
+        self._pendingAsset = AVURLAsset(url: url)
+        if let pendingAsset = _pendingAsset {
+            pendingAsset.loadValuesAsynchronously(forKeys: [Constants.assetPlayableKey], completionHandler: {
+                var error: NSError? = nil
+                let status = pendingAsset.statusOfValue(forKey: Constants.assetPlayableKey, error: &error)
+                
+                DispatchQueue.main.async {
+                    let isPendingAsset = (self._pendingAsset != nil && pendingAsset.isEqual(self._pendingAsset))
+                    
+                    switch status {
+                    case .loaded:
+                        if isPendingAsset {
+                            let currentItem = AVPlayerItem(asset: pendingAsset, automaticallyLoadedAssetKeys: [Constants.assetPlayableKey])
+                            currentItem.preferredForwardBufferDuration = self.bufferDuration
+                            self.avPlayer.automaticallyWaitsToMinimizeStalling = false
+                            self.avPlayer.replaceCurrentItem(with: currentItem)
+                            
+                            // Register for events
+                            self.playerTimeObserver.registerForBoundaryTimeEvents()
+                            self.playerObserver.startObserving()
+                            self.playerItemNotificationObserver.startObserving(item: currentItem)
+                            self.playerItemObserver.startObserving(item: currentItem)
+                        }
+                        break
+                        
+                    case .failed:
+                        // print("load asset failed")
+                        if isPendingAsset {
+                            self.delegate?.AVWrapper(failedWithError: error)
+                            self._pendingAsset = nil
+                        }
+                        break
+                        
+                    case .cancelled:
+                        // print("load asset cancelled")
+                        break
+                        
+                    default:
+                        break
+                    }
+                }
+            })
+        }
     }
     
     func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?) {
@@ -191,6 +228,11 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         playerItemObserver.stopObservingCurrentItem()
         playerTimeObserver.unregisterForBoundaryTimeEvents()
         playerItemNotificationObserver.stopObservingCurrentItem()
+        
+        if self._pendingAsset != nil {
+            self._pendingAsset?.cancelLoading()
+            self._pendingAsset = nil
+        }
         
         if !soft {
             avPlayer.replaceCurrentItem(with: nil)
@@ -216,6 +258,8 @@ extension AVPlayerWrapper: AVPlayerObserverDelegate {
             self._state = .loading
         case .playing:
             self._state = .playing
+        @unknown default:
+            break
         }
     }
     
@@ -233,12 +277,14 @@ extension AVPlayerWrapper: AVPlayerObserverDelegate {
             }
             
             break
-
+            
         case .failed:
             self.delegate?.AVWrapper(failedWithError: avPlayer.error)
             break
             
         case .unknown:
+            break
+        @unknown default:
             break
         }
     }


### PR DESCRIPTION
When using 1.1.4, there is a UI blocking delay.

This will load the tracks asynchronously and thus removing the UI thread blocking delay.

Fixes #548 