### PR TITLE
[android] Fix: Bad notification for startForeground: java.lang.Runtim…

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -1,8 +1,8 @@
 package com.guichaguri.trackplayer.service;
 
-import android.app.Activity;
-import android.app.Notification;
 import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -12,7 +12,6 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.media.session.MediaButtonReceiver;
 
-import android.support.v4.media.session.MediaSessionCompat;
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Arguments;
@@ -25,8 +24,23 @@ import javax.annotation.Nullable;
  */
 public class MusicService extends HeadlessJsTaskService {
 
+    private static final String MUSIC_SERVICE_NOTIFICATION_CHANNEL_ID = "MusicService";
+
     MusicManager manager;
     Handler handler;
+
+    @Override
+    public void onCreate(){
+        super.onCreate();
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+            NotificationChannel channel = new NotificationChannel(MUSIC_SERVICE_NOTIFICATION_CHANNEL_ID,"MusicService",
+                    NotificationManager.IMPORTANCE_LOW);
+            channel.setShowBadge(false);
+            channel.setSound(null, null);
+            ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE)).createNotificationChannel(channel);
+        }
+    }
 
     @Nullable
     @Override
@@ -77,7 +91,7 @@ public class MusicService extends HeadlessJsTaskService {
                 String channel = null;
 
                 if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    channel = NotificationChannel.DEFAULT_CHANNEL_ID;
+                    channel = MUSIC_SERVICE_NOTIFICATION_CHANNEL_ID;
                 }
 
                 // Sets the service to foreground with an empty notification


### PR DESCRIPTION
Fix bug:
Fatal Exception: android.app.RemoteServiceException
Bad notification for startForeground: java.lang.RuntimeException: invalid channel for service notification: null

The default  "Miscellaneous" notification channel (NotificationChannel.DEFAULT_CHANNEL_ID) doesn't exist on some devices