### PR TITLE
[react] fix hooks

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -553,7 +553,7 @@ import { Text, View } from 'react-native';
 import { useTrackPlayerProgress } from 'react-native-track-player';
 
 const MyComponent = () => {
-  const [{ position, bufferedPosition, duration }, setInterval] = useTrackPlayerProgress()
+  const { position, bufferedPosition, duration } = useTrackPlayerProgress()
 
   return (
     <View>

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,10 +1,6 @@
-import { useEffect, useState, useDebugValue } from 'react';
+import { useEffect, useState, useDebugValue, useRef } from 'react';
 import * as TrackPlayer from './index';
 import TrackPlayerEvents from './eventTypes';
-
-function isValidTrackPlayerEvent(evt) {
-    return TrackPlayerEvents[evt] !== undefined;
-}
 
 /**
  * @description
@@ -21,20 +17,21 @@ module.exports.useTrackPlayerEvents = (events, handler) => {
 
     useEffect(
         () => {
-            const playerEvents = events.filter(isValidTrackPlayerEvent); 
-
             if (__DEV__) {
-                if (events.length !== playerEvents.length) {
+                const allowedTypes = Object.values(TrackPlayerEvents);
+                const invalidTypes = events.filter(type => !allowedTypes.includes(type));
+                if (invalidTypes.length) {
                     console.warn(
                         'One or more of the events provided to useTrackPlayerEvents is ' +
-                        'not a valid TrackPlayer event. A list of available events can ' +
-                        'be found at https://react-native-kit.github.io/react-native-track-player/documentation/#events'
+                        `not a valid TrackPlayer event: ${invalidTypes.join('\', \'')}. ` +
+                        'A list of available events can be found at ' +
+                        'https://react-native-kit.github.io/react-native-track-player/documentation/#events'
                     )
                 }
             }
 
-            const subs = playerEvents.map(event => 
-                TrackPlayer.addEventListener(evt, 
+            const subs = events.map(event =>
+                TrackPlayer.addEventListener(event,
                     (payload) => savedHandler.current({ ...payload, type: event })
                 )
             );
@@ -43,7 +40,7 @@ module.exports.useTrackPlayerEvents = (events, handler) => {
                 subs.forEach(sub => sub.remove());
             }
         },
-        [events]
+        events
     );
 }
 
@@ -69,7 +66,7 @@ function useInterval(callback, delay) {
  *   Poll for track progress for the given interval (in miliseconds)
  * @param {number} interval - ms interval
  * @returns {[
- *   { 
+ *   {
  *      progress: number,
  *      bufferedPosition: number,
  *      duration: number
@@ -81,11 +78,10 @@ module.exports.useTrackPlayerProgress = (interval = 1000) => {
     const initialState = {
         position: 0,
         bufferedPosition: 0,
-        duration: 0 
+        duration: 0
     };
 
     const [state, setState] = useState(initialState);
-    const [interval, setInterval] = useState(interval);
 
     async function getProgress() {
         try {
@@ -104,5 +100,5 @@ module.exports.useTrackPlayerProgress = (interval = 1000) => {
 
     useInterval(getProgress, interval);
 
-    return [state, setInterval];
+    return state;
 }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -44,7 +44,7 @@ module.exports.useTrackPlayerEvents = (events, handler) => {
     );
 }
 
-function useInterval(callback, delay) {
+const useInterval = (callback, delay) => {
     const savedCallback = useRef();
 
     useEffect(() => {
@@ -52,13 +52,39 @@ function useInterval(callback, delay) {
     })
 
     useEffect(() => {
-        function tick() {
-            savedCallback.current();
-        }
-
-        const id = setInterval(tick, delay);
+        if (!delay) return;
+        const id = setInterval(savedCallback.current, delay);
         return () => clearInterval(id);
-    }, [delay]);
+    }, [interval]);
+}
+
+const useWhenPlaybackStateChanges = callback => {
+    useTrackPlayerEvents(
+        [TrackPlayerEvents.PLAYBACK_STATE],
+        ({ state }) => {
+            callback(state);
+        }
+    );
+    useEffect(() => {
+        let didCancel = false;
+        const fetchPlaybackState = async () => {
+            const playbackState = await TrackPlayer.getState();
+            if (!didCancel) {
+                callback(playbackState);
+            }
+        }
+        fetchPlaybackState();
+        return () => { didCancel = true };
+    }, []);
+}
+
+const usePlaybackStateIs = (...states) => {
+    const [is, setIs] = useState();
+    useWhenPlaybackStateChanges(state => {
+        setIs(states.includes(state));
+    });
+
+    return is;
 }
 
 /**
@@ -83,22 +109,19 @@ module.exports.useTrackPlayerProgress = (interval = 1000) => {
 
     const [state, setState] = useState(initialState);
 
-    async function getProgress() {
-        try {
-            const [position, bufferedPosition, duration] = await Promise.all([
-                TrackPlayer.getPosition(),
-                TrackPlayer.getBufferedPosition(),
-                TrackPlayer.getDuration()
-            ])
-
-            setState({ position, bufferedPosition, duration });
-        } catch (err) {
-            // The player is probably not ready yet.
-            // todo: better error handling
-        }
+    const getProgress = async () => {
+        const [position, bufferedPosition, duration] = await Promise.all([
+            TrackPlayer.getPosition(),
+            TrackPlayer.getBufferedPosition(),
+            TrackPlayer.getDuration()
+        ])
+        setState({ position, bufferedPosition, duration });
     }
 
-    useInterval(getProgress, interval);
-
+    const needsPoll = usePlaybackStateIs(
+        TrackPlayer.STATE_PLAYING,
+        TrackPlayer.STATE_BUFFERING
+    );
+    useInterval(getProgress, needsPoll ? interval : null);
     return state;
 }


### PR DESCRIPTION
I fixed a few things in the hooks while working on the example app:
- Add missing import
- Fix evt -> event variable name
- Fix warning of invalid types and avoid filtering in production, since subscribing to a non-existing event is not going to throw any errors. Add information about which event was invalid.
- Fix double const in useTrackPlayerProgress and just return the state, since we can control interval by what is passed into it
- only set progress interval when the player is either playing or buffering
- remove catching of player errors, since these functions should not be throwing errors (and if they do, we should fix the underlying cause)

@matthamil perhaps you would like to take a look?