### PR TITLE
[Android] Fix notification reinitialization after service is stopped

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -34,6 +34,7 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     private MusicEvents eventHandler;
     private ArrayDeque<Runnable> initCallbacks = new ArrayDeque<>();
     private boolean connecting = false;
+    private Bundle options;
 
     public MusicModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -69,6 +70,11 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     public void onServiceConnected(ComponentName name, IBinder service) {
         binder = (MusicBinder)service;
         connecting = false;
+
+        // Reapply options that user set before with updateOptions
+        if (this.options != null) {
+            binder.updateOptions(this.options);
+        }
 
         // Triggers all callbacks
         while(!initCallbacks.isEmpty()) {
@@ -171,6 +177,9 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     @ReactMethod
     public void updateOptions(ReadableMap data, final Promise callback) {
         final Bundle options = Arguments.toBundle(data);
+
+        // keep options as we may need them for correct MetadataManager reinitialization later
+        this.options = options;
 
         waitForConnection(() -> {
             binder.updateOptions(options);


### PR DESCRIPTION
On Android when playback is stopped (not paused) and playback service is not in foreground mode, it's killed after some time if application is background. On my Huawei mate 10 pro with Android 9 that happens exactly after 1 minute after you minimize the app.
After that if app is reopened and you start playback, waitForConnection starts service once again, but **you get notification without any controls / action buttons**. That happens because when service is stopped, MetadataManager is destroyed, and new instance is created when we start playback later, and that means that options that were set via updateOptions, including all these notification capabilities, are lost. 

This fix keeps specified options in MusicModule that is not destroyed on service stop, and reapplies options when service is rerun.