### PR TITLE
Revert "fix issue with url + fix bug"

### DIFF
--- a/ios/RNTrackPlayer/Models/MediaURL.swift
+++ b/ios/RNTrackPlayer/Models/MediaURL.swift
@@ -24,17 +24,8 @@ struct MediaURL {
             value = URL(string: encodedURI.replacingOccurrences(of: "file://", with: ""))!
         } else {
             let url = object as! String
-            let urlencoded = url.removingPercentEncoding
             isLocal = url.lowercased().hasPrefix("file://")
-            if let encoded = urlencoded!.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlFragmentAllowed
-                .union(.urlHostAllowed)
-                .union(.urlPasswordAllowed)
-                .union(.urlQueryAllowed)
-                .union(.urlUserAllowed)) {
-                value = URL(string: encoded.replacingOccurrences(of: "file://", with: ""))!
-            } else {
-                value = URL(string: url.replacingOccurrences(of: "file://", with: ""))!
-            }
+            value = URL(string: url.replacingOccurrences(of: "file://", with: ""))!
         }
     }
 }


### PR DESCRIPTION
Reverts react-native-kit/react-native-track-player#522

Fixes #617, fixes #543, fixes #564 

Pull request #522 is a breaking change and should not have been released except in a major release. In fact we should never encode/decode URLs as doing so will break URLs from some services like firebase which is used by a lot of users. If someone need to change URL encoding then he can do so before providing it to the player.