### PR TITLE
Update hooks.js

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -10,6 +10,13 @@ const usePlaybackState = () => {
     const [state, setState] = useState(TrackPlayer.STATE_NONE)
 
     useEffect(() => {
+        async function setPlayerState() {
+            const playerState = await TrackPlayer.getState()
+            setState(playerState)
+        }
+
+        setPlayerState()
+        
         const sub = TrackPlayer.addEventListener(TrackPlayer.TrackPlayerEvents.PLAYBACK_STATE, data => {
             setState(data.state)
         })


### PR DESCRIPTION
usePlaybackState hook is always returning STATE_NONE which is fine if you are only using it in one part of your app, but if you have multiple views you need the actual player state. This change fixes it.