### PR TITLE
Queue improvements

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -261,11 +261,14 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
         waitForConnection(() -> {
             ExoPlayback playback = binder.getPlayback();
             int size = playback.getQueue().size();
+            Integer currentIndex = playback.getCurrentTrackIndex();
 
             if (index < 0 || index >= size) {
                 callback.reject("index_out_of_bounds", "The track index is out of bounds");
             } else if (newIndex < 0 || newIndex >= size) {
                 callback.reject("index_out_of_bounds", "The new index is out of bounds");
+            } else if (index == currentIndex || newIndex == currentIndex) {
+                callback.reject("not_movable", "The current track cannot be moved");
             } else {
                 playback.move(index, newIndex, callback);
             }

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -196,7 +196,7 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     }
 
     @ReactMethod
-    public void add(ReadableArray tracks, final String insertBeforeId, final Promise callback) {
+    public void add(ReadableArray tracks, final Integer insertBeforeIndex, final Promise callback) {
         final ArrayList bundleList = Arguments.toList(tracks);
 
         waitForConnection(() -> {
@@ -210,21 +210,10 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
             }
 
             List<Track> queue = binder.getPlayback().getQueue();
-            int index = -1;
+            int index = insertBeforeIndex != null ? insertBeforeIndex : queue.size();
 
-            if(insertBeforeId != null) {
-                for(int i = 0; i < queue.size(); i++) {
-                    if(queue.get(i).id.equals(insertBeforeId)) {
-                        index = i;
-                        break;
-                    }
-                }
-            } else {
-                index = queue.size();
-            }
-
-            if(index == -1) {
-                callback.reject("track_not_in_queue", "Given track ID was not found in queue");
+            if(index < 0 || index > queue.size()) {
+                callback.reject("index_out_of_bounds", "The track index is out of bounds");
             } else if(trackList == null || trackList.isEmpty()) {
                 callback.reject("invalid_track_object", "Track is missing a required key");
             } else if(trackList.size() == 1) {
@@ -244,13 +233,10 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
             List<Integer> indexes = new ArrayList<>();
 
             for(Object o : trackList) {
-                String id = o.toString();
+                int index = o instanceof Integer ? (int)o : Integer.parseInt(o.toString());
 
-                for(int i = 0; i < queue.size(); i++) {
-                    if(queue.get(i).id.equals(id)) {
-                        indexes.add(i);
-                        break;
-                    }
+                if (index >= 0 && index < queue.size()) {
+                    indexes.add(index);
                 }
             }
 
@@ -287,25 +273,15 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     }
 
     @ReactMethod
-    public void updateMetadataForTrack(String id, ReadableMap map, final Promise callback) {
+    public void updateMetadataForTrack(int index, ReadableMap map, final Promise callback) {
         waitForConnection(() -> {
             ExoPlayback playback = binder.getPlayback();
             List<Track> queue = playback.getQueue();
-            Track track = null;
-            int index = -1;
 
-            for(int i = 0; i < queue.size(); i++) {
-                track = queue.get(i);
-
-                if(track.id.equals(id)) {
-                    index = i;
-                    break;
-                }
-            }
-
-            if(index == -1) {
-                callback.reject("track_not_in_queue", "No track found");
+            if(index < 0 || index >= queue.size()) {
+                callback.reject("index_out_of_bounds", "The index is out of bounds");
             } else {
+                Track track = queue.get(index);
                 track.setMetadata(getReactApplicationContext(), Arguments.toBundle(map), binder.getRatingType());
                 playback.updateTrack(index, track);
                 callback.resolve(null);
@@ -341,8 +317,8 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     }
 
     @ReactMethod
-    public void skip(final String track, final Promise callback) {
-        waitForConnection(() -> binder.getPlayback().skip(track, callback));
+    public void skip(final int index, final Promise callback) {
+        waitForConnection(() -> binder.getPlayback().skip(index, callback));
     }
 
     @ReactMethod
@@ -436,18 +412,15 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     }
 
     @ReactMethod
-    public void getTrack(final String id, final Promise callback) {
+    public void getTrack(final int index, final Promise callback) {
         waitForConnection(() -> {
             List<Track> tracks = binder.getPlayback().getQueue();
 
-            for(Track track : tracks) {
-                if(track.id.equals(id)) {
-                    callback.resolve(Arguments.fromBundle(track.originalItem));
-                    return;
-                }
+            if (index >= 0 && index < tracks.size()) {
+                callback.resolve(Arguments.fromBundle(tracks.get(index).originalItem));
+            } else {
+                callback.resolve(null);
             }
-
-            callback.resolve(null);
         });
     }
 
@@ -467,15 +440,7 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
 
     @ReactMethod
     public void getCurrentTrack(final Promise callback) {
-        waitForConnection(() -> {
-            Track track = binder.getPlayback().getCurrentTrack();
-
-            if(track == null) {
-                callback.resolve(null);
-            } else {
-                callback.resolve(track.id);
-            }
-        });
+        waitForConnection(() -> callback.resolve(binder.getPlayback().getCurrentTrackIndex()));
     }
 
     @ReactMethod

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -249,25 +249,6 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     }
 
     @ReactMethod
-    public void move(int index, int newIndex, final Promise callback) {
-        waitForConnection(() -> {
-            ExoPlayback playback = binder.getPlayback();
-            int size = playback.getQueue().size();
-            Integer currentIndex = playback.getCurrentTrackIndex();
-
-            if (index < 0 || index >= size) {
-                callback.reject("index_out_of_bounds", "The track index is out of bounds");
-            } else if (newIndex < 0 || newIndex >= size) {
-                callback.reject("index_out_of_bounds", "The new index is out of bounds");
-            } else if (index == currentIndex || newIndex == currentIndex) {
-                callback.reject("not_movable", "The current track cannot be moved");
-            } else {
-                playback.move(index, newIndex, callback);
-            }
-        });
-    }
-
-    @ReactMethod
     public void updateMetadataForTrack(int index, ReadableMap map, final Promise callback) {
         waitForConnection(() -> {
             ExoPlayback playback = binder.getPlayback();

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -12,6 +12,7 @@ import android.util.Log;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import com.facebook.react.bridge.*;
 import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Player;
 import com.guichaguri.trackplayer.service.MusicBinder;
 import com.guichaguri.trackplayer.service.MusicService;
 import com.guichaguri.trackplayer.service.Utils;
@@ -149,6 +150,11 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
         constants.put("RATING_5_STARS", RatingCompat.RATING_5_STARS);
         constants.put("RATING_PERCENTAGE", RatingCompat.RATING_PERCENTAGE);
 
+        // Repeat Modes
+        constants.put("REPEAT_OFF", Player.REPEAT_MODE_OFF);
+        constants.put("REPEAT_TRACK", Player.REPEAT_MODE_ONE);
+        constants.put("REPEAT_QUEUE", Player.REPEAT_MODE_ALL);
+
         return constants;
     }
 
@@ -252,6 +258,30 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
                 binder.getPlayback().remove(indexes, callback);
             } else {
                 callback.resolve(null);
+            }
+        });
+    }
+
+    @ReactMethod
+    public void shuffle(final Promise callback) {
+        waitForConnection(() -> {
+            binder.getPlayback().shuffle(callback);
+            callback.resolve(null);
+        });
+    }
+
+    @ReactMethod
+    public void move(int index, int newIndex, final Promise callback) {
+        waitForConnection(() -> {
+            ExoPlayback playback = binder.getPlayback();
+            int size = playback.getQueue().size();
+
+            if (index < 0 || index >= size) {
+                callback.reject("index_out_of_bounds", "The track index is out of bounds");
+            } else if (newIndex < 0 || newIndex >= size) {
+                callback.reject("index_out_of_bounds", "The new index is out of bounds");
+            } else {
+                playback.move(index, newIndex, callback);
             }
         });
     }
@@ -390,6 +420,19 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     @ReactMethod
     public void getRate(final Promise callback) {
         waitForConnection(() -> callback.resolve(binder.getPlayback().getRate()));
+    }
+
+    @ReactMethod
+    public void setRepeatMode(int mode, final Promise callback) {
+        waitForConnection(() -> {
+            binder.getPlayback().setRepeatMode(mode);
+            callback.resolve(null);
+        });
+    }
+
+    @ReactMethod
+    public void getRepeatMode(int mode, final Promise callback) {
+        waitForConnection(() -> callback.resolve(binder.getPlayback().getRepeatMode()));
     }
 
     @ReactMethod

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -210,7 +210,8 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
             }
 
             List<Track> queue = binder.getPlayback().getQueue();
-            int index = insertBeforeIndex != null ? insertBeforeIndex : queue.size();
+            // -1 means no index was passed and therefore should be inserted at the end.
+            int index = insertBeforeIndex != -1 ? insertBeforeIndex : queue.size();
 
             if(index < 0 || index > queue.size()) {
                 callback.reject("index_out_of_bounds", "The track index is out of bounds");
@@ -234,6 +235,10 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
 
             for(Object o : trackList) {
                 int index = o instanceof Integer ? (int)o : Integer.parseInt(o.toString());
+
+                // we do not allow removal of the current item
+                int currentIndex = binder.getPlayback().getCurrentTrackIndex();
+                if (index == currentIndex) continue;
 
                 if (index >= 0 && index < queue.size()) {
                     indexes.add(index);

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -150,11 +150,6 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
         constants.put("RATING_5_STARS", RatingCompat.RATING_5_STARS);
         constants.put("RATING_PERCENTAGE", RatingCompat.RATING_PERCENTAGE);
 
-        // Repeat Modes
-        constants.put("REPEAT_OFF", Player.REPEAT_MODE_OFF);
-        constants.put("REPEAT_TRACK", Player.REPEAT_MODE_ONE);
-        constants.put("REPEAT_QUEUE", Player.REPEAT_MODE_ALL);
-
         return constants;
     }
 
@@ -250,14 +245,6 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
             } else {
                 callback.resolve(null);
             }
-        });
-    }
-
-    @ReactMethod
-    public void shuffle(final Promise callback) {
-        waitForConnection(() -> {
-            binder.getPlayback().shuffle(callback);
-            callback.resolve(null);
         });
     }
 
@@ -404,19 +391,6 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     @ReactMethod
     public void getRate(final Promise callback) {
         waitForConnection(() -> callback.resolve(binder.getPlayback().getRate()));
-    }
-
-    @ReactMethod
-    public void setRepeatMode(int mode, final Promise callback) {
-        waitForConnection(() -> {
-            binder.getPlayback().setRepeatMode(mode);
-            callback.resolve(null);
-        });
-    }
-
-    @ReactMethod
-    public void getRepeatMode(int mode, final Promise callback) {
-        waitForConnection(() -> callback.resolve(binder.getPlayback().getRepeatMode()));
     }
 
     @ReactMethod

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -212,16 +212,16 @@ public class MusicManager implements OnAudioFocusChangeListener {
             metadata.updatePlayback(playback);
     }
 
-    public void onTrackUpdate(Track previous, long prevPos, Track next) {
+    public void onTrackUpdate(Integer prevIndex, long prevPos, Integer nextIndex, Track next) {
         Log.d(Utils.LOG, "onTrackUpdate");
 
         if(playback.shouldAutoUpdateMetadata() && next != null)
             metadata.updateMetadata(playback, next);
 
         Bundle bundle = new Bundle();
-        bundle.putString("track", previous != null ? previous.id : null);
+        if (prevIndex != null) bundle.putInt("track", prevIndex);
         bundle.putDouble("position", Utils.toSeconds(prevPos));
-        bundle.putString("nextTrack", next != null ? next.id : null);
+        if (nextIndex != null) bundle.putInt("nextTrack", nextIndex);
         service.emit(MusicEvents.PLAYBACK_TRACK_CHANGED, bundle);
     }
 
@@ -229,11 +229,11 @@ public class MusicManager implements OnAudioFocusChangeListener {
         metadata.removeNotifications();
     }
 
-    public void onEnd(Track previous, long prevPos) {
+    public void onEnd(Integer previousIndex, long prevPos) {
         Log.d(Utils.LOG, "onEnd");
 
         Bundle bundle = new Bundle();
-        bundle.putString("track", previous != null ? previous.id : null);
+        if (previousIndex != null) bundle.putInt("track", previousIndex);
         bundle.putDouble("position", Utils.toSeconds(prevPos));
         service.emit(MusicEvents.PLAYBACK_QUEUE_ENDED, bundle);
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/ButtonEvents.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/ButtonEvents.java
@@ -90,11 +90,11 @@ public class ButtonEvents extends MediaSessionCompat.Callback {
     public void onSkipToQueueItem(long id) {
         List<Track> tracks = manager.getPlayback().getQueue();
 
-        for(Track track : tracks) {
-            if(track.queueId != id) continue;
+        for(int i = 0; i < tracks.size(); i++) {
+            if(tracks.get(i).queueId != id) continue;
 
             Bundle bundle = new Bundle();
-            bundle.putString("id", track.id);
+            bundle.putInt("index", i);
             service.emit(MusicEvents.BUTTON_SKIP, bundle);
             break;
         }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -63,7 +63,7 @@ public class Track extends TrackMetadata {
     public final long queueId;
 
     public Track(Context context, Bundle bundle, int ratingType) {
-        id = bundle.getString("id");
+        id = bundle.getString("id", null);
 
         resourceId = Utils.getRawResourceId(context, bundle, "url");
 
@@ -112,7 +112,10 @@ public class Track extends TrackMetadata {
         MediaMetadataCompat.Builder builder = super.toMediaMetadata();
 
         builder.putString(METADATA_KEY_MEDIA_URI, uri.toString());
-        builder.putString(METADATA_KEY_MEDIA_ID, id);
+
+        if (id != null) {
+            builder.putString(METADATA_KEY_MEDIA_ID, id);
+        }
 
         return builder;
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -47,7 +47,6 @@ public class Track extends TrackMetadata {
         return tracks;
     }
 
-    public String id;
     public Uri uri;
     public int resourceId;
 
@@ -63,8 +62,6 @@ public class Track extends TrackMetadata {
     public final long queueId;
 
     public Track(Context context, Bundle bundle, int ratingType) {
-        id = bundle.getString("id", null);
-
         resourceId = Utils.getRawResourceId(context, bundle, "url");
 
         if(resourceId == 0) {
@@ -113,10 +110,6 @@ public class Track extends TrackMetadata {
 
         builder.putString(METADATA_KEY_MEDIA_URI, uri.toString());
 
-        if (id != null) {
-            builder.putString(METADATA_KEY_MEDIA_ID, id);
-        }
-
         return builder;
     }
 
@@ -124,7 +117,6 @@ public class Track extends TrackMetadata {
         MediaDescriptionCompat descr = new MediaDescriptionCompat.Builder()
                 .setTitle(title)
                 .setSubtitle(artist)
-                .setMediaId(id)
                 .setMediaUri(uri)
                 .setIconUri(artwork)
                 .build();

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -321,9 +321,9 @@ public abstract class ExoPlayback<T extends Player> implements EventListener, Me
             previousState = state;
 
             if(state == PlaybackStateCompat.STATE_STOPPED) {
-                Track previous = getCurrentTrack();
+                Integer previous = getCurrentTrackIndex();
                 long position = getPosition();
-                manager.onTrackUpdate(previous, position, null);
+                manager.onTrackUpdate(previous, position, null, null);
                 manager.onEnd(getCurrentTrackIndex(), getPosition());
             }
         }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -72,7 +72,15 @@ public abstract class ExoPlayback<T extends Player> implements EventListener, Me
 
     public abstract void remove(List<Integer> indexes, Promise promise);
 
+    public abstract void move(int index, int newIndex, Promise promise);
+
     public abstract void removeUpcomingTracks();
+
+    public abstract void shuffle(final Promise promise);
+
+    public abstract void setRepeatMode(int repeatMode);
+
+    public abstract int getRepeatMode();
 
     public void updateTrack(int index, Track track) {
         int currentIndex = player.getCurrentWindowIndex();

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -72,8 +72,6 @@ public abstract class ExoPlayback<T extends Player> implements EventListener, Me
 
     public abstract void remove(List<Integer> indexes, Promise promise);
 
-    public abstract void move(int index, int newIndex, Promise promise);
-
     public abstract void removeUpcomingTracks();
 
     public void updateTrack(int index, Track track) {

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -76,12 +76,6 @@ public abstract class ExoPlayback<T extends Player> implements EventListener, Me
 
     public abstract void removeUpcomingTracks();
 
-    public abstract void shuffle(final Promise promise);
-
-    public abstract void setRepeatMode(int repeatMode);
-
-    public abstract int getRepeatMode();
-
     public void updateTrack(int index, Track track) {
         int currentIndex = player.getCurrentWindowIndex();
 
@@ -327,16 +321,6 @@ public abstract class ExoPlayback<T extends Player> implements EventListener, Me
                 manager.onEnd(getCurrentTrackIndex(), getPosition());
             }
         }
-    }
-
-    @Override
-    public void onRepeatModeChanged(int repeatMode) {
-        // Repeat mode update
-    }
-
-    @Override
-    public void onShuffleModeEnabledChanged(boolean shuffleModeEnabled) {
-        // Shuffle mode update
     }
 
     @Override

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
@@ -144,13 +144,20 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
     @Override
     public void shuffle(final Promise promise) {
         Random rand = new Random();
+        int startIndex = player.getCurrentWindowIndex();
         int length = queue.size();
 
-        // Fisher-Yates shuffle
-        for (int i = 0; i < length; i++) {
-            int swapIndex = rand.nextInt(i + 1);
+        if (startIndex == C.INDEX_UNSET) {
+            startIndex = 0;
+        } else {
+            startIndex++;
+        }
 
-            queue.add(swapIndex, queue.remove(i));
+        // Fisher-Yates shuffle
+        for (int i = startIndex; i < length; i++) {
+            int swapIndex = rand.nextInt(i + 1 - startIndex) + startIndex;
+
+            Collections.swap(queue, i, swapIndex);
 
             if (length - 1 == i) {
                 // Resolve the promise after the last move command

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
@@ -126,7 +126,7 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
 
     @Override
     public void move(int index, int newIndex, Promise promise) {
-        queue.add(newIndex, queue.remove(index));
+        Collections.swap(queue, index, newIndex);
         source.moveMediaSource(index, newIndex, manager.getHandler(), Utils.toRunnable(promise));
     }
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
@@ -73,7 +73,7 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
     public void add(Track track, int index, Promise promise) {
         queue.add(index, track);
         MediaSource trackSource = track.toMediaSource(context, this);
-        source.addMediaSource(index, trackSource, manager.getHandler(), Utils.toRunnable(promise));
+        source.addMediaSource(index, trackSource, manager.getHandler(), () -> promise.resolve(index));
 
         prepare();
     }
@@ -87,7 +87,7 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
         }
 
         queue.addAll(index, tracks);
-        source.addMediaSources(index, trackList, manager.getHandler(), Utils.toRunnable(promise));
+        source.addMediaSources(index, trackList, manager.getHandler(), () -> promise.resolve(index));
 
         prepare();
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
@@ -124,12 +124,6 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
     }
 
     @Override
-    public void move(int index, int newIndex, Promise promise) {
-        Collections.swap(queue, index, newIndex);
-        source.moveMediaSource(index, newIndex, manager.getHandler(), Utils.toRunnable(promise));
-    }
-
-    @Override
     public void removeUpcomingTracks() {
         int currentIndex = player.getCurrentWindowIndex();
         if (currentIndex == C.INDEX_UNSET) return;

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
@@ -203,13 +203,13 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
 
     @Override
     public void reset() {
-        Track track = getCurrentTrack();
+        Integer track = getCurrentTrackIndex();
         long position = player.getCurrentPosition();
 
         super.reset();
         resetQueue();
 
-        manager.onTrackUpdate(track, position, null);
+        manager.onTrackUpdate(track, position, null, null);
     }
 
     @Override

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/LocalPlayback.java
@@ -11,7 +11,6 @@ import com.google.android.exoplayer2.database.DatabaseProvider;
 import com.google.android.exoplayer2.database.ExoDatabaseProvider;
 import com.google.android.exoplayer2.source.ConcatenatingMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.ShuffleOrder;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.cache.CacheDataSource;
 import com.google.android.exoplayer2.upstream.cache.CacheDataSourceFactory;
@@ -139,42 +138,6 @@ public class LocalPlayback extends ExoPlayback<SimpleExoPlayer> {
             queue.remove(i);
             source.removeMediaSource(i);
         }
-    }
-
-    @Override
-    public void shuffle(final Promise promise) {
-        Random rand = new Random();
-        int startIndex = player.getCurrentWindowIndex();
-        int length = queue.size();
-
-        if (startIndex == C.INDEX_UNSET) {
-            startIndex = 0;
-        } else {
-            startIndex++;
-        }
-
-        // Fisher-Yates shuffle
-        for (int i = startIndex; i < length; i++) {
-            int swapIndex = rand.nextInt(i + 1 - startIndex) + startIndex;
-
-            Collections.swap(queue, i, swapIndex);
-
-            if (length - 1 == i) {
-                // Resolve the promise after the last move command
-                source.moveMediaSource(i, swapIndex, manager.getHandler(), Utils.toRunnable(promise));
-            } else {
-                source.moveMediaSource(i, swapIndex);
-            }
-        }
-    }
-
-    @Override
-    public void setRepeatMode(int repeatMode) {
-        player.setRepeatMode(repeatMode);
-    }
-
-    public int getRepeatMode() {
-        return player.getRepeatMode();
     }
 
     private void resetQueue() {

--- a/docs/API.md
+++ b/docs/API.md
@@ -41,8 +41,7 @@ You can add a track to the player using a url or by requiring a file in the app 
 First of all, you need to create a [track object](https://react-native-kit.github.io/react-native-track-player/documentation/#track-object), which is a plain javascript object with a number of properties describing the track. Then [add](https://react-native-kit.github.io/react-native-track-player/documentation/#addtracks-insertbeforeid) the track to the queue:
 
 ```javascript
-const track1 = {
-    id: 'avaritia', // Must be a string, required
+var track = {
     url: 'http://example.com/avaritia.mp3', // Load media from the network
     title: 'Avaritia',
     artist: 'deadmau5',
@@ -72,7 +71,7 @@ const track3 = {
     duration: 411
 };
 
-// Add the tracks to the queue:
+// You can then [add](https://react-native-kit.github.io/react-native-track-player/documentation/#addtracks-insertbeforeindex) the items to the queue
 await TrackPlayer.add([track1, track2, track3]);
 ```
 
@@ -84,8 +83,8 @@ if (state === TrackPlayer.STATE_PLAYING) {
     console.log('The player is playing');
 };
 
-const trackId = await TrackPlayer.getCurrentTrack();
-const trackObject = await TrackPlayer.getTrack(trackId);
+let trackIndex = await TrackPlayer.getCurrentTrack();
+let trackObject = await TrackPlayer.getTrack(trackIndex);
 console.log(`Title: ${trackObject.title}`);
 
 const position = await TrackPlayer.getPosition();
@@ -110,8 +109,8 @@ TrackPlayer.setVolume(0.5);
 
 ### Controlling the Queue
 ```javascript
-// Skip to a specific track id:
-await TrackPlayer.skip('the-track-id');
+// Skip to a specific track index:
+await TrackPlayer.skip(trackIndex);
 
 // Skip to the next track in the queue:
 await TrackPlayer.skipToNext();
@@ -120,7 +119,7 @@ await TrackPlayer.skipToNext();
 await TrackPlayer.skipToPrevious();
 
 // Remove two tracks from the queue:
-await TrackPlayer.remove([trackId1, trackId2]);
+await TrackPlayer.remove([trackIndex1, trackIndex2]);
 
 // Retrieve the track objects in the queue:
 const tracks = await TrackPlayer.getQueue();

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -177,16 +177,6 @@ Removes one or more tracks from the queue.
 | ------ | -------- | ------------- |
 | tracks | `array` of track indexes or a single one | The tracks that will be removed |
 
-#### `move(index, newIndex)`
-Moves a track to a new position.
-
-**Returns:** `Promise`
-
-| Param    | Type     | Description     |
-| -------- | -------- | --------------- |
-| index    | `number` | The track index |
-| newIndex | `number` | Its new index   |
-
 #### `skip(index)`
 Skips to a track in the queue.
 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -15,6 +15,7 @@ redirect_from:
   * [State](#state)
   * [Rating](#rating)
   * [Capability](#capability)
+  * [Repeat Mode](#repeat-mode)
   * [Pitch Algorithm](#pitch-algorithm)
 * [Functions](#functions)
   * [Lifecycle](#lifecycle-functions)
@@ -85,6 +86,14 @@ Capability indicating the ability to set the rating value based on the rating ty
 Capability indicating the ability to jump forward by the amount of seconds specified in the options
 #### `CAPABILITY_JUMP_BACKWARD`
 Capability indicating the ability to jump backward by the amount of seconds specified in the options
+
+### Repeat Mode
+#### `REPEAT_OFF`
+Doesn't repeat.
+#### `REPEAT_TRACK`
+Loops the current track.
+#### `REPEAT_QUEUE`
+Repeats the whole queue.
 
 ### Pitch Algorithm
 #### `PITCH_ALGORITHM_LINEAR`
@@ -158,15 +167,15 @@ Registers an event handler. This function should only be called once, and should
 | handler | `function` | The function that acts as an event handler |
 
 ### Queue Functions
-#### `add(tracks, insertBeforeId)`
+#### `add(tracks, insertBeforeIndex)`
 Adds one or more tracks to the queue.
 
-**Returns:** `Promise`
+**Returns:** `Promise<number>` - The promise resolves with the first added track index
 
 | Param          | Type     | Description   |
 | -------------- | -------- | ------------- |
 | tracks         | `array` of [Track Object](#track-object) or a single one | The tracks that will be added |
-| insertBeforeId | `string` | The ID of the track that will be located immediately after the inserted tracks. Set it to `null` to add it at the end of the queue |
+| insertBeforeIndex | `number` | The index of the track that will be located immediately after the inserted tracks. Set it to `null` to add it at the end of the queue |
 
 #### `remove(tracks)`
 Removes one or more tracks from the queue.
@@ -175,16 +184,26 @@ Removes one or more tracks from the queue.
 
 | Param  | Type     | Description   |
 | ------ | -------- | ------------- |
-| tracks | `array` of track ids or a single one | The tracks that will be removed |
+| tracks | `array` of track indexes or a single one | The tracks that will be removed |
 
-#### `skip(id)`
+#### `move(index, newIndex)`
+Moves a track to a new position.
+
+**Returns:** `Promise`
+
+| Param    | Type     | Description     |
+| -------- | -------- | --------------- |
+| index    | `number` | The track index |
+| newIndex | `number` | Its new index   |
+
+#### `skip(index)`
 Skips to a track in the queue.
 
 **Returns:** `Promise`
 
-| Param  | Type     | Description   |
-| ------ | -------- | ------------- |
-| id  | `string` | The track id  |
+| Param  | Type     | Description     |
+| ------ | -------- | --------------- |
+| index  | `number` | The track index |
 
 #### `skipToNext()`
 Skips to the next track in the queue.
@@ -199,19 +218,19 @@ Skips to the previous track in the queue.
 #### `reset()`
 Resets the player stopping the current track and clearing the queue.
 
-#### `getTrack(id)`
+#### `getTrack(index)`
 Gets a track object from the queue.
 
 **Returns:** `Promise<`Object as described in [Track Object](#track-object)`>`
 
-| Param    | Type       | Description   |
-| -------- | ---------- | ------------- |
-| id       | `string`   | The track ID  |
+| Param    | Type       | Description     |
+| -------- | ---------- | --------------- |
+| index    | `number`   | The track index |
 
 #### `getCurrentTrack()`
-Gets the id of the current track
+Gets the index of the current track
 
-**Returns:** `Promise<string>`
+**Returns:** `Promise<number>`
 
 #### `getQueue()`
 Gets the whole queue
@@ -221,7 +240,7 @@ Gets the whole queue
 #### `removeUpcomingTracks()`
 Clears any upcoming tracks from the queue.
 
-#### `updateMetadataForTrack(id, metadata)`
+#### `updateMetadataForTrack(index, metadata)`
 Updates the metadata of a track in the queue.
 If the current track is updated, the notification and the Now Playing Center will be updated accordingly.
 
@@ -229,8 +248,20 @@ If the current track is updated, the notification and the Now Playing Center wil
 
 | Param    | Type       | Description   |
 | -------- | ---------- | ------------- |
-| id       | `string`   | The track ID  |
+| index    | `number`   | The track index  |
 | metadata | `object`   | A subset of the [Track Object](#track-object) with only the `artwork`, `title`, `artist`, `album`, `description`, `genre`, `date`, `rating` and `duration` properties. |
+
+#### `setRepeatMode(mode)`
+Sets the repeat mode.
+
+| Param    | Type       | Description     |
+| -------- | ---------- | --------------- |
+| mode     | [Repeat Mode](#repeat-mode) | The repeat mode |
+
+#### `getRepeatMode()`
+Gets the repeat mode.
+
+**Returns:** [Repeat Mode](#repeat-mode)
 
 ### Player Functions
 #### `updateOptions(options)`
@@ -376,7 +407,7 @@ Fired when the user skips to a track in the queue. Only fired if the `CAPABILITY
 
 | Param | Type     | Description   |
 | ----- | -------- | ------------- |
-| id    | `string` | The track id  |
+| index | `number` | The track index  |
 
 #### `remote-next`
 Fired when the user presses the next track button. Only fired if the `CAPABILITY_SKIP_TO_NEXT` is allowed.
@@ -440,16 +471,16 @@ Fired when a track is changed.
 
 | Param     | Type     | Description                            |
 | --------- | -------- | -------------------------------------- |
-| track     | `string` | The previous track id. Might be null   |
+| track     | `number` | The previous track index. Might be null   |
 | position  | `number` | The previous track position in seconds |
-| nextTrack | `string` | The next track id. Might be null       |
+| nextTrack | `number` | The next track index. Might be null       |
 
 #### `playback-queue-ended`
 Fired when the queue reaches the end.
 
 | Param    | Type     | Description                               |
 | -------- | -------- | ----------------------------------------- |
-| track    | `string` | The previous track id. Might be null      |
+| track    | `number` | The previous track index. Might be null      |
 | position | `number` | The previous track position in seconds    |
 
 #### `playback-metadata-received`
@@ -492,7 +523,7 @@ A component base that updates itself every second with a new position. Your app 
 ### Track Object
 Tracks in the player queue are plain javascript objects as described below.
 
-Only the `id`, `url`, `title` and `artist` properties are required for basic playback
+Only the `url`, `title` and `artist` properties are required for basic playback
 
 | Param          | Type                        | Description  |
 | -------------- | --------------------------- | ------------ |

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -15,7 +15,6 @@ redirect_from:
   * [State](#state)
   * [Rating](#rating)
   * [Capability](#capability)
-  * [Repeat Mode](#repeat-mode)
   * [Pitch Algorithm](#pitch-algorithm)
 * [Functions](#functions)
   * [Lifecycle](#lifecycle-functions)
@@ -86,14 +85,6 @@ Capability indicating the ability to set the rating value based on the rating ty
 Capability indicating the ability to jump forward by the amount of seconds specified in the options
 #### `CAPABILITY_JUMP_BACKWARD`
 Capability indicating the ability to jump backward by the amount of seconds specified in the options
-
-### Repeat Mode
-#### `REPEAT_OFF`
-Doesn't repeat.
-#### `REPEAT_TRACK`
-Loops the current track.
-#### `REPEAT_QUEUE`
-Repeats the whole queue.
 
 ### Pitch Algorithm
 #### `PITCH_ALGORITHM_LINEAR`
@@ -250,18 +241,6 @@ If the current track is updated, the notification and the Now Playing Center wil
 | -------- | ---------- | ------------- |
 | index    | `number`   | The track index  |
 | metadata | `object`   | A subset of the [Track Object](#track-object) with only the `artwork`, `title`, `artist`, `album`, `description`, `genre`, `date`, `rating` and `duration` properties. |
-
-#### `setRepeatMode(mode)`
-Sets the repeat mode.
-
-| Param    | Type       | Description     |
-| -------- | ---------- | --------------- |
-| mode     | [Repeat Mode](#repeat-mode) | The repeat mode |
-
-#### `getRepeatMode()`
-Gets the repeat mode.
-
-**Returns:** [Repeat Mode](#repeat-mode)
 
 ### Player Functions
 #### `updateOptions(options)`

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -73,7 +73,7 @@ const App = () => {
   const [trackArtist, setTrackArtist] = useState<string>();
 
   useTrackPlayerEvents([Event.PlaybackTrackChanged], async event => {
-    if (event.type === Event.PlaybackTrackChanged && !!event.nextTrack) {
+    if (event.type === Event.PlaybackTrackChanged && event.nextTrack != null) {
       const track = await TrackPlayer.getTrack(event.nextTrack);
       const {title, artist, artwork} = track || {};
       setTrackTitle(title);
@@ -81,6 +81,7 @@ const App = () => {
       setTrackArtwork(artwork);
     }
   });
+
   useEffect(() => {
     setup();
   }, []);

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -39,7 +39,6 @@ const setup = async () => {
 
   await TrackPlayer.add(playlistData);
   await TrackPlayer.add({
-    id: 'local-track',
     url: localTrack,
     title: 'Pure (Demo)',
     artist: 'David Chavez',
@@ -74,7 +73,7 @@ const App = () => {
   const [trackArtist, setTrackArtist] = useState<string>();
 
   useTrackPlayerEvents([Event.PlaybackTrackChanged], async event => {
-    if (event.type === Event.PlaybackTrackChanged) {
+    if (event.type === Event.PlaybackTrackChanged && !!event.nextTrack) {
       const track = await TrackPlayer.getTrack(event.nextTrack);
       const {title, artist, artwork} = track || {};
       setTrackTitle(title);

--- a/example/react/data/playlist.json
+++ b/example/react/data/playlist.json
@@ -1,6 +1,5 @@
 [
   {
-    "id": "1111",
     "url": "https://drive.google.com/uc?export=download&id=1AjPwylDJgR8DOnmJWeRgZzjsohi-7ekj",
     "title": "Longing",
     "artist": "David Chavez",
@@ -8,7 +7,6 @@
     "duration": 143
   },
   {
-    "id": "2222",
     "url": "https://drive.google.com/uc?export=download&id=1VM9_umeyzJn0v1pRzR1BSm9y3IhZ3c0E",
     "title": "Soul Searching (Demo)",
     "artist": "David Chavez",
@@ -16,7 +14,6 @@
     "duration": 77
   },
   {
-    "id": "3333",
     "url": "https://drive.google.com/uc?export=download&id=1bmvPOy2IVbkUROgm0dqiZry_miiL4OqI",
     "title": "Lullaby (Demo)",
     "artist": "David Chavez",
@@ -24,7 +21,6 @@
     "duration": 71
   },
   {
-    "id": "4444",
     "url": "https://drive.google.com/uc?export=download&id=1V-c_WmanMA9i5BwfkmTs-605BQDsfyzC",
     "title": "Rhythm City (Demo)",
     "artist": "David Chavez",

--- a/ios/RNTrackPlayer/Models/Track.swift
+++ b/ios/RNTrackPlayer/Models/Track.swift
@@ -11,7 +11,6 @@ import MediaPlayer
 import AVFoundation
 
 class Track: NSObject, AudioItem, TimePitching, AssetOptionsProviding {
-    let id: String
     let url: MediaURL
     
     @objc var title: String
@@ -32,13 +31,11 @@ class Track: NSObject, AudioItem, TimePitching, AssetOptionsProviding {
     private var originalObject: [String: Any]
     
     init?(dictionary: [String: Any]) {
-        guard let id = dictionary["id"] as? String,
-            let title = dictionary["title"] as? String,
+        guard let title = dictionary["title"] as? String,
             let artist = dictionary["artist"] as? String,
             let url = MediaURL(object: dictionary["url"])
             else { return nil }
         
-        self.id = id
         self.url = url
         self.title = title
         self.artist = artist

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -70,10 +70,9 @@ public class RNTrackPlayer: RCTEventEmitter {
             "CAPABILITY_DISLIKE": Capability.dislike.rawValue,
             "CAPABILITY_BOOKMARK": Capability.bookmark.rawValue,
 
-            // TODO: Tie this to actual values on the audio player.
-            "REPEAT_OFF": 0,
-            "REPEAT_TRACK": 1,
-            "REPEAT_QUEUE": 2,
+            "REPEAT_OFF": RepeatMode.off.rawValue,
+            "REPEAT_TRACK": RepeatMode.track.rawValue,
+            "REPEAT_QUEUE": RepeatMode.queue.rawValue,
         ]
     }
     
@@ -420,6 +419,18 @@ public class RNTrackPlayer: RCTEventEmitter {
         print("Seeking to \(time) seconds")
         player.seek(to: time)
         resolve(NSNull())
+    }
+
+    @objc(setRepeatMode:resolver:rejecter:)
+    public func setRepeatMode(repeatMode: NSNumber, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        player.repeatMode = RepeatMode(rawValue: repeatMode.intValue) ?? .off
+        resolve(NSNull())
+    }
+
+    @objc(getRepeatMode:rejecter:)
+    public func getRepeatMode(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        print("Getting current repeatMode")
+        resolve(player.repeatMode.rawValue)
     }
     
     @objc(setVolume:resolver:rejecter:)

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -69,10 +69,6 @@ public class RNTrackPlayer: RCTEventEmitter {
             "CAPABILITY_LIKE": Capability.like.rawValue,
             "CAPABILITY_DISLIKE": Capability.dislike.rawValue,
             "CAPABILITY_BOOKMARK": Capability.bookmark.rawValue,
-
-            "REPEAT_OFF": RepeatMode.off.rawValue,
-            "REPEAT_TRACK": RepeatMode.track.rawValue,
-            "REPEAT_QUEUE": RepeatMode.queue.rawValue,
         ]
     }
     
@@ -419,18 +415,6 @@ public class RNTrackPlayer: RCTEventEmitter {
         print("Seeking to \(time) seconds")
         player.seek(to: time)
         resolve(NSNull())
-    }
-
-    @objc(setRepeatMode:resolver:rejecter:)
-    public func setRepeatMode(repeatMode: NSNumber, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        player.repeatMode = RepeatMode(rawValue: repeatMode.intValue) ?? .off
-        resolve(NSNull())
-    }
-
-    @objc(getRepeatMode:rejecter:)
-    public func getRepeatMode(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        print("Getting current repeatMode")
-        resolve(player.repeatMode.rawValue)
     }
     
     @objc(setVolume:resolver:rejecter:)

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -69,6 +69,11 @@ public class RNTrackPlayer: RCTEventEmitter {
             "CAPABILITY_LIKE": Capability.like.rawValue,
             "CAPABILITY_DISLIKE": Capability.dislike.rawValue,
             "CAPABILITY_BOOKMARK": Capability.bookmark.rawValue,
+
+            // TODO: Tie this to actual values on the audio player.
+            "REPEAT_OFF": 0,
+            "REPEAT_TRACK": 1,
+            "REPEAT_QUEUE": 2,
         ]
     }
     
@@ -298,7 +303,7 @@ public class RNTrackPlayer: RCTEventEmitter {
     }
     
     @objc(add:before:resolver:rejecter:)
-    public func add(trackDicts: [[String: Any]], before trackId: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    public func add(trackDicts: [[String: Any]], before trackIndex: NSNumber, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             UIApplication.shared.beginReceivingRemoteControlEvents();
         }
@@ -312,39 +317,26 @@ public class RNTrackPlayer: RCTEventEmitter {
             
             tracks.append(track)
         }
-        
-        print("Adding tracks:", tracks)
-        
-        if let trackId = trackId {
-            guard let insertIndex = player.items.firstIndex(where: { ($0 as! Track).id == trackId })
-                else {
-                    reject("track_not_in_queue", "Given track ID was not found in queue", nil)
-                    return
-            }
-            
-            try? player.add(items: tracks, at: insertIndex)
+
+        if (trackIndex.intValue > player.items.count) {
+            reject("index_out_of_bounds", "The track index is out of bounds", nil)
+        } else if trackIndex.intValue == -1 { // -1 means no index was passed and therefore should be inserted at the end.
+            try? player.add(items: tracks)
         } else {
-            try? player.add(items: tracks, playWhenReady: false)
+            try? player.add(items: tracks, at: trackIndex.intValue)
         }
         
         resolve(NSNull())
     }
     
     @objc(remove:resolver:rejecter:)
-    public func remove(tracks ids: [String], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        print("Removing tracks:", ids)
-        
-        // Look through queue for tracks that match one of the provided ids.
-        // Do this in reverse order so that as they are removed, 
-        // it will not affect other indices that will be removed.
-        for (index, element) in player.items.enumerated().reversed() {
-            // skip the current index
+    public func remove(tracks indexes: [Int], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        print("Removing tracks:", indexes)
+
+        for index in indexes {
+            // we do not allow removal of the current item
             if index == player.currentIndex { continue }
-            
-            let track = element as! Track
-            if ids.contains(track.id) {
-                try? player.removeItem(at: index)
-            }
+            try? player.removeItem(at: index)
         }
 
         resolve(NSNull())
@@ -358,15 +350,14 @@ public class RNTrackPlayer: RCTEventEmitter {
     }
     
     @objc(skip:resolver:rejecter:)
-    public func skip(to trackId: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        guard let trackIndex = player.items.firstIndex(where: { ($0 as! Track).id == trackId })
-            else {
-                reject("track_not_in_queue", "Given track ID was not found in queue", nil)
-                return
+    public func skip(to trackIndex: NSNumber, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        if (trackIndex.intValue < 0 || trackIndex.intValue > player.items.count) {
+            reject("index_out_of_bounds", "The track index is out of bounds", nil)
+            return
         }
         
-        print("Skipping to track:", trackId)
-        try? player.jumpToItem(atIndex: trackIndex, playWhenReady: player.playerState == .playing)
+        print("Skipping to track:", trackIndex)
+        try? player.jumpToItem(atIndex: trackIndex.intValue, playWhenReady: player.playerState == .playing)
         resolve(NSNull())
     }
     
@@ -458,13 +449,13 @@ public class RNTrackPlayer: RCTEventEmitter {
     }
     
     @objc(getTrack:resolver:rejecter:)
-    public func getTrack(id: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        guard let track = player.items.first(where: { ($0 as! Track).id == id })
-            else {
-                reject("track_not_in_queue", "Given track ID was not found in queue", nil)
-                return
+    public func getTrack(index: NSNumber, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        if (index.intValue < 0 || index.intValue > player.items.count) {
+            reject("index_out_of_bounds", "The track index is out of bounds", nil)
+            return
         }
-        
+
+        let track = player.items[index.intValue]
         resolve((track as? Track)?.toObject())
     }
     
@@ -476,7 +467,7 @@ public class RNTrackPlayer: RCTEventEmitter {
     
     @objc(getCurrentTrack:rejecter:)
     public func getCurrentTrack(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        resolve((player.currentItem as? Track)?.id)
+        resolve(player.currentIndex)
     }
     
     @objc(getDuration:rejecter:)
@@ -500,17 +491,19 @@ public class RNTrackPlayer: RCTEventEmitter {
     }
     
     @objc(updateMetadataForTrack:metadata:resolver:rejecter:)
-    public func updateMetadata(for trackId: String, metadata: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        guard let track = player.items.first(where: { ($0 as! Track).id == trackId }) as? Track
-            else {
-                reject("track_not_in_queue", "Given track ID was not found in queue", nil)
-                return
+    public func updateMetadata(for trackIndex: NSNumber, metadata: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        if (trackIndex.intValue < 0 || trackIndex.intValue > player.items.count) {
+            reject("index_out_of_bounds", "The track index is out of bounds", nil)
+            return
         }
-        
+
+        let track = player.items[trackIndex.intValue] as! Track
         track.updateMetadata(dictionary: metadata)
-        if (player.currentItem as! Track).id == track.id {
+
+        if (player.currentIndex == trackIndex.intValue) {
             Metadata.update(for: player, with: metadata)
         }
+
         resolve(NSNull())
     }
     

--- a/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
@@ -22,28 +22,13 @@ import MediaPlayer
 * lock screen controls.
 */
 
-public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
+public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer, QueueManagerDelegate {
 
 	public var reactEventEmitter: RCTEventEmitter
 
 	// Used to store the rate that is given in TrackPlayer.setRate() so that we
 	// can maintain the same rate in cases when SwiftAudio would not.
 	private var _rate: Float
-
-	// Override _currentItem so that we can send an event when it changes.
-	override var _currentItem: AudioItem? {
-		willSet(newCurrentItem) {
-			if ((newCurrentItem as? Track) === (_currentItem as? Track)) {
-				return
-			}
-
-            self.reactEventEmitter.sendEvent(withName: "playback-track-changed", body: [
-                "track": currentItem != nil ? currentIndex : nil,
-                "position": self.currentTime,
-                "nextTrack": newCurrentItem != nil ? currentIndex + 1 : nil,
-            ])
-		}
-	}
 
 	// Override rate so that we can maintain the same rate on future tracks.
 	override public var rate: Float {
@@ -63,6 +48,7 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
         self._rate = 1.0
 		self.reactEventEmitter = reactEventEmitter
 		super.init()
+        self.queueManager.delegate = self
     }
 
 	// MARK: - AVPlayerWrapperDelegate
@@ -86,18 +72,11 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
     }
     
     override func AVWrapperItemDidPlayToEndTime() {
+        // fire an event for the queue ending
         if self.nextItems.count == 0 {
-            // For consistency sake, send an event for the track changing to nothing
-            self.reactEventEmitter.sendEvent(withName: "playback-track-changed", body: [
-                "track": currentItem != nil ? currentIndex : nil,
-                "position": self.currentTime,
-                "nextTrack": nil,
-            ])
-
-            // fire an event for the queue ending
             self.reactEventEmitter.sendEvent(withName: "playback-queue-ended", body: [
-                "track": currentItem != nil ? currentIndex : nil,
-                "position": self.currentTime,
+                "track": currentIndex,
+                "position": currentTime,
             ])
 		} 
 		super.AVWrapperItemDidPlayToEndTime()
@@ -125,5 +104,25 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
 			// RNTrackPlayer.updateOptions()
 			// self.enableRemoteCommands(remoteCommands)
         }
+    }
+
+    // MARK: - Private Helpers
+
+    private func onTrackUpdate(previousIndex: Int?, nextIndex: Int?) {
+        reactEventEmitter.sendEvent(withName: "playback-track-changed", body: [
+            "track": previousIndex,
+            "position": currentTime,
+            "nextTrack": nextIndex,
+        ])
+    }
+
+    // MARK: - QueueManagerDelegate
+
+    func onCurrentIndexChanged(oldIndex: Int, newIndex: Int) {
+        onTrackUpdate(previousIndex: oldIndex, nextIndex: newIndex)
+    }
+
+    func onReceivedFirstItem() {
+        onTrackUpdate(previousIndex: nil, nextIndex: 0)
     }
 }

--- a/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
@@ -51,6 +51,11 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer, QueueManagerDelegate {
         self.queueManager.delegate = self
     }
 
+    public override func stop() {
+        super.stop()
+        onTrackUpdate(previousIndex: currentIndex, nextIndex: nil)
+    }
+
 	// MARK: - AVPlayerWrapperDelegate
     
     override func AVWrapper(didChangeState state: AVPlayerWrapperState) {

--- a/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
@@ -37,11 +37,11 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
 				return
 			}
 
-			self.reactEventEmitter.sendEvent(withName: "playback-track-changed", body: [
-				"track": (_currentItem as? Track)?.id ?? nil,
-				"position": self.currentTime,
-				"nextTrack": (newCurrentItem as? Track)?.id ?? nil,
-				])
+            self.reactEventEmitter.sendEvent(withName: "playback-track-changed", body: [
+                "track": currentItem != nil ? currentIndex : nil,
+                "position": self.currentTime,
+                "nextTrack": newCurrentItem != nil ? currentIndex + 1 : nil,
+            ])
 		}
 	}
 
@@ -87,18 +87,18 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
     
     override func AVWrapperItemDidPlayToEndTime() {
         if self.nextItems.count == 0 {
-			// For consistency sake, send an event for the track changing to nothing
-			self.reactEventEmitter.sendEvent(withName: "playback-track-changed", body: [
-				"track": (self.currentItem as? Track)?.id ?? nil,
-				"position": self.currentTime,
-				"nextTrack": nil,
-				])
+            // For consistency sake, send an event for the track changing to nothing
+            self.reactEventEmitter.sendEvent(withName: "playback-track-changed", body: [
+                "track": currentItem != nil ? currentIndex : nil,
+                "position": self.currentTime,
+                "nextTrack": nil,
+            ])
 
-			// fire an event for the queue ending
-			self.reactEventEmitter.sendEvent(withName: "playback-queue-ended", body: [
-				"track": (self.currentItem as? Track)?.id,
-				"position": self.currentTime,
-				])
+            // fire an event for the queue ending
+            self.reactEventEmitter.sendEvent(withName: "playback-queue-ended", body: [
+                "track": currentItem != nil ? currentIndex : nil,
+                "position": self.currentTime,
+            ])
 		} 
 		super.AVWrapperItemDidPlayToEndTime()
     }

--- a/ios/RNTrackPlayer/RNTrackPlayerBridge.m
+++ b/ios/RNTrackPlayer/RNTrackPlayerBridge.m
@@ -59,6 +59,13 @@ RCT_EXTERN_METHOD(seekTo:(double)time
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(setRepeatMode:(nonnull NSNumber *)repeatMode
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject);
+
+RCT_EXTERN_METHOD(getRepeatMode:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject);
+
 RCT_EXTERN_METHOD(setVolume:(float)volume
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);

--- a/ios/RNTrackPlayer/RNTrackPlayerBridge.m
+++ b/ios/RNTrackPlayer/RNTrackPlayerBridge.m
@@ -22,7 +22,7 @@ RCT_EXTERN_METHOD(updateOptions:(NSDictionary *)options
                   rejecter:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(add:(NSArray *)objects
-                  before:(NSString *)trackId
+                  before:(nonnull NSNumber *)trackIndex
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
@@ -33,7 +33,7 @@ RCT_EXTERN_METHOD(remove:(NSArray *)objects
 RCT_EXTERN_METHOD(removeUpcomingTracks:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
-RCT_EXTERN_METHOD(skip:(NSString *)trackId
+RCT_EXTERN_METHOD(skip:(nonnull NSNumber *)trackIndex
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
@@ -73,7 +73,7 @@ RCT_EXTERN_METHOD(setRate:(float)rate
 RCT_EXTERN_METHOD(getRate:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
-RCT_EXTERN_METHOD(getTrack:(NSString *)trackId
+RCT_EXTERN_METHOD(getTrack:(nonnull NSNumber *)trackIndex
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
@@ -95,7 +95,7 @@ RCT_EXTERN_METHOD(getPosition:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(getState:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
-RCT_EXTERN_METHOD(updateMetadataForTrack:(NSString *)trackId
+RCT_EXTERN_METHOD(updateMetadataForTrack:(nonnull NSNumber *)trackIndex
                   metadata:(NSDictionary *)metadata
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);

--- a/ios/RNTrackPlayer/RNTrackPlayerBridge.m
+++ b/ios/RNTrackPlayer/RNTrackPlayerBridge.m
@@ -59,13 +59,6 @@ RCT_EXTERN_METHOD(seekTo:(double)time
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
-RCT_EXTERN_METHOD(setRepeatMode:(nonnull NSNumber *)repeatMode
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject);
-
-RCT_EXTERN_METHOD(getRepeatMode:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject);
-
 RCT_EXTERN_METHOD(setVolume:(float)volume
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -59,10 +59,6 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         self.playerTimeObserver.delegate = self
         self.playerItemNotificationObserver.delegate = self
         self.playerItemObserver.delegate = self
-
-        // Disable external video output, so we can get the audio controls when
-        // using AirPlay.
-        self.avPlayer.allowsExternalPlayback = false;
         
         playerTimeObserver.registerForPeriodicTimeEvents()
     }
@@ -137,12 +133,10 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     }
     
     func play() {
-        _playWhenReady = true
         avPlayer.play()
     }
     
     func pause() {
-        _playWhenReady = false
         avPlayer.pause()
     }
     

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AudioItem.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AudioItem.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AVFoundation
+import UIKit
 
 public enum SourceType {
     case stream

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/NowPlayingInfoController/NowPlayingInfoController.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/NowPlayingInfoController/NowPlayingInfoController.swift
@@ -8,47 +8,43 @@
 import Foundation
 import MediaPlayer
 
-public class NowPlayingInfoController: NowPlayingInfoControllerProtocol {
 
+public class NowPlayingInfoController: NowPlayingInfoControllerProtocol {
+    
     private var _infoCenter: NowPlayingInfoCenter
     private var _info: [String: Any] = [:]
-
+    
     var infoCenter: NowPlayingInfoCenter {
         return _infoCenter
     }
-
+    
     var info: [String: Any] {
         return _info
     }
-
+    
     public required init() {
         self._infoCenter = MPNowPlayingInfoCenter.default()
     }
-
+    
     public required init(infoCenter: NowPlayingInfoCenter) {
         self._infoCenter = infoCenter
     }
-
+    
     public func set(keyValues: [NowPlayingInfoKeyValue]) {
-        DispatchQueue.main.async {
-            keyValues.forEach { (keyValue) in
-                self._info[keyValue.getKey()] = keyValue.getValue()
-            }
-            self._infoCenter.nowPlayingInfo = self._info
+        keyValues.forEach { (keyValue) in
+            _info[keyValue.getKey()] = keyValue.getValue()
         }
+        self._infoCenter.nowPlayingInfo = _info
     }
-
+    
     public func set(keyValue: NowPlayingInfoKeyValue) {
-        DispatchQueue.main.async {
-            self._info[keyValue.getKey()] = keyValue.getValue()
-            self._infoCenter.nowPlayingInfo = self._info
-        }
+        _info[keyValue.getKey()] = keyValue.getValue()
+        self._infoCenter.nowPlayingInfo = _info
     }
-
+    
     public func clear() {
-        DispatchQueue.main.async {
-            self._info = [:]
-            self._infoCenter.nowPlayingInfo = self._info
-        }
+        self._info = [:]
+        self._infoCenter.nowPlayingInfo = _info
     }
+    
 }

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/QueueManager.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/QueueManager.swift
@@ -7,10 +7,22 @@
 
 import Foundation
 
+protocol QueueManagerDelegate: class {
+    func onReceivedFirstItem()
+    func onCurrentIndexChanged(oldIndex: Int, newIndex: Int)
+}
 
 class QueueManager<T> {
-    
-    private var _items: [T] = []
+
+    weak var delegate: QueueManagerDelegate? = nil
+
+    private var _items: [T] = [] {
+        didSet {
+            if oldValue.count == 0 && _items.count > 0 && _currentIndex == 0 {
+                delegate?.onReceivedFirstItem()
+            }
+        }
+    }
     
     /**
      All items held by the queue.
@@ -33,7 +45,11 @@ class QueueManager<T> {
         return Array(_items[0..<_currentIndex])
     }
     
-    private var _currentIndex: Int = 0
+    private var _currentIndex: Int = 0 {
+        didSet {
+            delegate?.onCurrentIndexChanged(oldIndex: oldValue, newIndex: _currentIndex)
+        }
+    }
     
     /**
      The index of the current item.

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/QueuedAudioPlayer.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/QueuedAudioPlayer.swift
@@ -14,12 +14,9 @@ import MediaPlayer
 public class QueuedAudioPlayer: AudioPlayer {
     
     let queueManager: QueueManager = QueueManager<AudioItem>()
-    
-    /**
-     Set wether the player should automatically play the next song when a song is finished.
-     Default is `true`.
-     */
-    public var automaticallyPlayNextSong: Bool = true
+
+    /// The repeat mode for the queue player.
+    public var repeatMode: RepeatMode = .off
     
     public override var currentItem: AudioItem? {
         return queueManager.current
@@ -185,9 +182,20 @@ public class QueuedAudioPlayer: AudioPlayer {
     
     override func AVWrapperItemDidPlayToEndTime() {
         super.AVWrapperItemDidPlayToEndTime()
-        if automaticallyPlayNextSong {
-            try? self.next()
+
+        switch repeatMode {
+        case .off: try? self.next()
+        case .track:
+            seek(to: 0)
+            play()
+        case .queue:
+            do {
+                try self.next()
+            } catch APError.QueueError.noNextItem {
+                do {
+                    try jumpToItem(atIndex: 0, playWhenReady: true)
+                } catch { /* TODO: handle possible errors from load */ }
+            } catch { /* TODO: handle possible errors from load */ }
         }
     }
-    
 }

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RepeatMode.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RepeatMode.swift
@@ -1,0 +1,14 @@
+//
+//  RepeatMode.swift
+//  SwiftAudio
+//
+//  Created by David Chavez on 29.05.21.
+//
+
+import Foundation
+
+public enum RepeatMode: Int {
+    case off
+    case track
+    case queue
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import {
   State,
   TrackMetadataBase,
   NowPlayingMetadata,
-  RepeatMode,
 } from './interfaces'
 
 const { TrackPlayerModule: TrackPlayer } = NativeModules
@@ -161,10 +160,6 @@ async function setRate(rate: number): Promise<void> {
   return TrackPlayer.setRate(rate)
 }
 
-async function setRepeatMode(mode: RepeatMode): Promise<RepeatMode> {
-  return TrackPlayer.setRepeatMode(mode)
-}
-
 // MARK: - Getters
 
 async function getVolume(): Promise<number> {
@@ -203,10 +198,6 @@ async function getState(): Promise<State> {
   return TrackPlayer.getState()
 }
 
-async function getRepeatMode(): Promise<RepeatMode> {
-  return TrackPlayer.getRepeatMode()
-}
-
 export * from './hooks'
 export * from './interfaces'
 
@@ -240,7 +231,6 @@ export default {
   seekTo,
   setVolume,
   setRate,
-  setRepeatMode,
 
   // MARK: - Getters
   getVolume,
@@ -252,5 +242,4 @@ export default {
   getBufferedPosition,
   getPosition,
   getState,
-  getRepeatMode,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ async function add(tracks: Track | Track[], insertBeforeIndex?: number): Promise
   }
 
   // Note: we must be careful about passing nulls to non nullable parameters on Android.
-  return TrackPlayer.add(tracks, insertBeforeIndex || 0)
+  return TrackPlayer.add(tracks, insertBeforeIndex || -1)
 }
 
 async function move(index: number, newIndex: number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   State,
   TrackMetadataBase,
   NowPlayingMetadata,
+  RepeatMode,
 } from './interfaces'
 
 const { TrackPlayerModule: TrackPlayer } = NativeModules
@@ -49,7 +50,7 @@ function addEventListener(event: Event, listener: (data: any) => void) {
 
 // MARK: - Queue API
 
-async function add(tracks: Track | Track[], insertBeforeId?: string): Promise<void> {
+async function add(tracks: Track | Track[], insertBeforeIndex?: number): Promise<void> {
   // Clone the array before modifying it
   if (Array.isArray(tracks)) {
     tracks = [...tracks]
@@ -66,15 +67,16 @@ async function add(tracks: Track | Track[], insertBeforeId?: string): Promise<vo
     // Resolve the URLs
     tracks[i].url = resolveImportedPath(tracks[i].url)
     tracks[i].artwork = resolveImportedPath(tracks[i].artwork)
-
-    // Cast ID's into strings
-    tracks[i].id = `${tracks[i].id}`
   }
 
-  return TrackPlayer.add(tracks, insertBeforeId)
+  return TrackPlayer.add(tracks, insertBeforeIndex)
 }
 
-async function remove(tracks: string | string[]): Promise<void> {
+async function move(index: number, newIndex: number) {
+  return TrackPlayer.move(index, newIndex)
+}
+
+async function remove(tracks: number | number[]): Promise<void> {
   if (!Array.isArray(tracks)) {
     tracks = [tracks]
   }
@@ -86,8 +88,8 @@ async function removeUpcomingTracks(): Promise<void> {
   return TrackPlayer.removeUpcomingTracks()
 }
 
-async function skip(trackId: string): Promise<void> {
-  return TrackPlayer.skip(trackId)
+async function skip(trackIndex: number): Promise<void> {
+  return TrackPlayer.skip(trackIndex)
 }
 
 async function skipToNext(): Promise<void> {
@@ -116,8 +118,8 @@ async function updateOptions(options: MetadataOptions = {}): Promise<void> {
   return TrackPlayer.updateOptions(options)
 }
 
-async function updateMetadataForTrack(trackId: string, metadata: TrackMetadataBase): Promise<void> {
-  return TrackPlayer.updateMetadataForTrack(trackId, metadata)
+async function updateMetadataForTrack(trackIndex: number, metadata: TrackMetadataBase): Promise<void> {
+  return TrackPlayer.updateMetadataForTrack(trackIndex, metadata)
 }
 
 function clearNowPlayingMetadata(): Promise<void> {
@@ -128,7 +130,7 @@ function updateNowPlayingMetadata(metadata: NowPlayingMetadata): Promise<void> {
   return TrackPlayer.updateNowPlayingMetadata(metadata)
 }
 
-// MARK: - Playback API
+// MARK: - Player API
 
 async function reset(): Promise<void> {
   return TrackPlayer.reset()
@@ -158,6 +160,10 @@ async function setRate(rate: number): Promise<void> {
   return TrackPlayer.setRate(rate)
 }
 
+async function setRepeatMode(mode: RepeatMode): Promise<RepeatMode> {
+  return TrackPlayer.setRepeatMode(mode)
+}
+
 // MARK: - Getters
 
 async function getVolume(): Promise<number> {
@@ -168,15 +174,15 @@ async function getRate(): Promise<number> {
   return TrackPlayer.getRate()
 }
 
-async function getTrack(trackId: string): Promise<Track> {
-  return TrackPlayer.getTrack(trackId)
+async function getTrack(trackIndex: number): Promise<Track> {
+  return TrackPlayer.getTrack(trackIndex)
 }
 
 async function getQueue(): Promise<Track[]> {
   return TrackPlayer.getQueue()
 }
 
-async function getCurrentTrack(): Promise<string> {
+async function getCurrentTrack(): Promise<number> {
   return TrackPlayer.getCurrentTrack()
 }
 
@@ -196,6 +202,10 @@ async function getState(): Promise<State> {
   return TrackPlayer.getState()
 }
 
+async function getRepeatMode(): Promise<RepeatMode> {
+  return TrackPlayer.getRepeatMode()
+}
+
 export * from './hooks'
 export * from './interfaces'
 
@@ -208,6 +218,7 @@ export default {
 
   // MARK: - Queue API
   add,
+  move,
   remove,
   removeUpcomingTracks,
   skip,
@@ -220,7 +231,7 @@ export default {
   clearNowPlayingMetadata,
   updateNowPlayingMetadata,
 
-  // MARK: - Playback API
+  // MARK: - Player API
   reset,
   play,
   pause,
@@ -228,6 +239,7 @@ export default {
   seekTo,
   setVolume,
   setRate,
+  setRepeatMode,
 
   // MARK: - Getters
   getVolume,
@@ -239,4 +251,5 @@ export default {
   getBufferedPosition,
   getPosition,
   getState,
+  getRepeatMode,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,8 @@ async function add(tracks: Track | Track[], insertBeforeIndex?: number): Promise
     tracks[i].artwork = resolveImportedPath(tracks[i].artwork)
   }
 
-  return TrackPlayer.add(tracks, insertBeforeIndex)
+  // Note: we must be careful about passing nulls to non nullable parameters on Android.
+  return TrackPlayer.add(tracks, insertBeforeIndex || 0)
 }
 
 async function move(index: number, newIndex: number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,10 +72,6 @@ async function add(tracks: Track | Track[], insertBeforeIndex?: number): Promise
   return TrackPlayer.add(tracks, insertBeforeIndex || -1)
 }
 
-async function move(index: number, newIndex: number) {
-  return TrackPlayer.move(index, newIndex)
-}
-
 async function remove(tracks: number | number[]): Promise<void> {
   if (!Array.isArray(tracks)) {
     tracks = [tracks]
@@ -210,7 +206,6 @@ export default {
 
   // MARK: - Queue API
   add,
-  move,
   remove,
   removeUpcomingTracks,
   skip,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -142,11 +142,6 @@ export enum TrackType {
   SmoothStreaming = 'smoothstreaming',
 }
 
-export enum RepeatMode {
-  Off = TrackPlayer.REPEAT_OFF,
-  Track = TrackPlayer.REPEAT_TRACK,
-  Queue = TrackPlayer.REPEAT_QUEUE,
-}
 
 export enum PitchAlgorithm {
   Linear = TrackPlayer.PITCH_ALGORITHM_LINEAR,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -142,6 +142,12 @@ export enum TrackType {
   SmoothStreaming = 'smoothstreaming',
 }
 
+export enum RepeatMode {
+  Off = TrackPlayer.REPEAT_MODE_OFF,
+  Track = TrackPlayer.REPEAT_MODE_TRACK,
+  Queue = TrackPlayer.REPEAT_MODE_QUEUE,
+}
+
 export enum PitchAlgorithm {
   Linear = TrackPlayer.PITCH_ALGORITHM_LINEAR,
   Music = TrackPlayer.PITCH_ALGORITHM_MUSIC,
@@ -175,7 +181,6 @@ export interface NowPlayingMetadata extends TrackMetadataBase {
 }
 
 export interface Track extends TrackMetadataBase {
-  id: string
   url: string | ResourceObject
   type?: TrackType
   userAgent?: string

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -143,9 +143,9 @@ export enum TrackType {
 }
 
 export enum RepeatMode {
-  Off = TrackPlayer.REPEAT_MODE_OFF,
-  Track = TrackPlayer.REPEAT_MODE_TRACK,
-  Queue = TrackPlayer.REPEAT_MODE_QUEUE,
+  Off = TrackPlayer.REPEAT_OFF,
+  Track = TrackPlayer.REPEAT_TRACK,
+  Queue = TrackPlayer.REPEAT_QUEUE,
 }
 
 export enum PitchAlgorithm {


### PR DESCRIPTION
This PR adds a few queue improvements. Closes #122.

* Replaced track IDs to track queue indexes
    * Functions that used to reject with `track_not_in_queue` or `invalid_id` will now reject with `index_out_of_bounds` when the index is invalid.
* Added `move(index, newIndex)` - Moves a track from an index to another.
    * Returns a promise, rejecting with `index_out_of_bounds` when any of the indexes are invalid.
* Added `shuffle()` - Shuffles the queue using the Fisher-Yates algorithm.
    * Returns a promise, resolving when the shuffle is finished.
* Added `setRepeatMode(mode)` - Updates the repeat mode:
    * `REPEAT_OFF` - doesn't repeat.
    * `REPEAT_TRACK` - loops the current track.
    * `REPEAT_QUEUE` - repeats the whole queue.
* Added `getRepeatMode()`