### PR TITLE
[iOS] Add swift version to podspec

### DIFF
--- a/react-native-track-player.podspec
+++ b/react-native-track-player.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => package['repository']['url'], :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,swift}"
+  s.swift_version = "4.2"
 
   s.dependency "React"
 end


### PR DESCRIPTION
added Swift version, default version is Swift 4.0(with Auto linking)
It occur Swift compile error when building after auto link, so we need specify Swift version in pod spec (it can be fixed by manually choose Swift version above 4.2, but it is not efficiently)

![image](https://user-images.githubusercontent.com/26326015/62540104-c1a38a80-b891-11e9-9c1b-82376e831b1b.png)

I'm using react-native-track-player@2.0.0-rc13