### PR TITLE
Fixes Int Options Casting Error

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -149,4 +149,13 @@ public class Utils {
         }
     }
 
+    private int getInt(Bundle data, String key, int defaultValue) {
+        Object valueAsObject = data.get(key);
+        if (valueAsObject instanceof Integer) {
+            return data.getInt(key, defaultValue);
+        } else if (valueAsObject instanceof Double) {
+            return (int) data.getDouble(key, defaultValue);
+        }
+        return defaultValue;
+    }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -149,12 +149,10 @@ public class Utils {
         }
     }
 
-    private int getInt(Bundle data, String key, int defaultValue) {
-        Object valueAsObject = data.get(key);
-        if (valueAsObject instanceof Integer) {
-            return data.getInt(key, defaultValue);
-        } else if (valueAsObject instanceof Double) {
-            return (int) data.getDouble(key, defaultValue);
+    public static int getInt(Bundle data, String key, int defaultValue) {
+        Object value = data.get(key);
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
         }
         return defaultValue;
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -138,16 +138,16 @@ public class MetadataManager {
         }
 
         // Update the color
-        builder.setColor(options.getInt("color", NotificationCompat.COLOR_DEFAULT));
+        builder.setColor(Utils.getInt(options, "color", NotificationCompat.COLOR_DEFAULT));
 
         // Update the icon
         builder.setSmallIcon(getIcon(options, "icon", R.drawable.play));
 
         // Update the jump interval
-        jumpInterval = options.getInt("jumpInterval", 15);
+        jumpInterval = Utils.getInt(options, "jumpInterval", 15);
 
         // Update the rating type
-        ratingType = options.getInt("ratingType", RatingCompat.RATING_NONE);
+        ratingType = Utils.getInt(options, "ratingType", RatingCompat.RATING_NONE);
         session.setRatingType(ratingType);
 
         updateNotification();


### PR DESCRIPTION
Summary:
Depending on the implementation of the map, the value passed from RN is either an int or double.
This fixes the casting error by checking first the type of the object.
The fix is applied to all `getInt` instances thus fixes color, jumpInterval and ratingType.

Test Plan:
I manually verified in the debugger that all three values show up as Double and thus need to use the workaround. After the parsing method is added, the values are correctly assigned to the fields / builder. 

Before:
```
08-13 22:22:27.181  6122  6122 E UpdatedJumpInterval: interval: 15
```

After:
```
08-13 22:21:05.814  5855  5855 E UpdatedJumpInterval: interval: 30
```

30 is the expected value passed from RN instead of the default value.

Exception:
```
08-13 22:18:30.265  5322  5322 W Bundle  : Key jumpInterval expected Integer but value was a java.lang.Double.  The default value 15 was returned.
08-13 22:18:30.266  5322  5322 W Bundle  : Attempt to cast generated internal exception:
08-13 22:18:30.266  5322  5322 W Bundle  : java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Integer
08-13 22:18:30.266  5322  5322 W Bundle  : 	at android.os.BaseBundle.getInt(BaseBundle.java:1036)
08-13 22:18:30.266  5322  5322 W Bundle  : 	at com.guichaguri.trackplayer.service.metadata.MetadataManager.updateOptions(MetadataManager.java:148)
08-13 22:18:30.266  5322  5322 W Bundle  : 	at com.guichaguri.trackplayer.service.MusicBinder.updateOptions(MusicBinder.java:48)
08-13 22:18:30.266  5322  5322 W Bundle  : 	at com.guichaguri.trackplayer.module.MusicModule.lambda$updateOptions$1$MusicModule(MusicModule.java:174)
08-13 22:18:30.266  5322  5322 W Bundle  : 	at com.guichaguri.trackplayer.module.-$$Lambda$MusicModule$qmyfj_MJHRafHlk_JBz_7FW8mx0.run(Unknown Source:6)
```