### PR TITLE
Add prioritizeTimeOverSize setting for Android buffer

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -120,11 +120,13 @@ public class MusicManager implements OnAudioFocusChangeListener {
         int playBuffer = (int)Utils.toMillis(options.getDouble("playBuffer", Utils.toSeconds(DEFAULT_BUFFER_FOR_PLAYBACK_MS)));
         int backBuffer = (int)Utils.toMillis(options.getDouble("backBuffer", Utils.toSeconds(DEFAULT_BACK_BUFFER_DURATION_MS)));
         long cacheMaxSize = (long)(options.getDouble("maxCacheSize", 0) * 1024);
+        boolean prioritizeTimeOverSize = options.getBoolean("prioritizeTimeOverSize", false);
         int multiplier = DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS / DEFAULT_BUFFER_FOR_PLAYBACK_MS;
 
         LoadControl control = new DefaultLoadControl.Builder()
                 .setBufferDurationsMs(minBuffer, maxBuffer, playBuffer, playBuffer * multiplier)
                 .setBackBuffer(backBuffer, false)
+                .setPrioritizeTimeOverSizeThresholds(prioritizeTimeOverSize)
                 .createDefaultLoadControl();
 
         SimpleExoPlayer player = ExoPlayerFactory.newSimpleInstance(service, new DefaultRenderersFactory(service), new DefaultTrackSelector(), control);

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -106,6 +106,7 @@ If the player is already initialized, the promise will resolve instantly.
 | options              | `object` | The options   | 
 | options.minBuffer    | `number` | Minimum time in seconds that needs to be buffered | 15 | ✓ | ✗ | ✗ |
 | options.maxBuffer    | `number` | Maximum time in seconds that needs to be buffered | 50 | ✓ | ✗ | ✗ |
+| options.prioritizeTimeOverSize | `boolean` | Whether buffer cache should prioritize time settings over size. If you're setting `minBuffer`, you probably want to set this to `true`. | false | ✓ | ✗ | ✗ |
 | options.playBuffer   | `number` | Minimum time in seconds that needs to be buffered to start playing | 2.5 | ✓ | ✗ | ✗ |
 | options.backBuffer   | `number` | Time in seconds that should be kept in the buffer behind the current playhead time. | 0 | ✓ | ✗ | ✗ |
 | options.maxCacheSize | `number` | Maximum cache size in kilobytes | 0 | ✓ | ✗ | ✗ |

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,7 @@ declare namespace RNTrackPlayer {
   export interface PlayerOptions {
     minBuffer?: number;
     maxBuffer?: number;
+    prioritizeTimeOverSize?: boolean;
     playBuffer?: number;
     maxCacheSize?: number;
     iosCategory?: 'playback' | 'playAndRecord' | 'multiRoute' | 'ambient' | 'soloAmbient' | 'record';


### PR DESCRIPTION
Default is `false` to maintain backward compatibility. If you're configuring minBuffer and maxBuffer, you probably want to set this to `true`. Setting to `true` ensures that your `minBuffer` setting will always be met when possible. When it is false, ExoPlayer has a separate targetBufferSize that may trigger loading of the resource to pause even if minBuffer is not met.

In ExoPlayer, audio tracks have a [default buffer size of ~3.5MB](https://exoplayer.dev/doc/reference/constant-values.html#com.google.android.exoplayer2.C.DEFAULT_AUDIO_BUFFER_SIZE). If I have an audio file that's 12MB and set `minBuffer` to 10 minutes and use the default settings, ExoPlayer will not fill the minimum buffer to 10 minutes. It will stop filling the buffer after it has ~3.5MB of data. However, if I set `prioritizeTimeOverSize` to `true`, then ExoPlayer will fill the buffer until we've reached `minBuffer` rather than stopping at the default audio buffer size. The logic for this can be found in [`shouldeContinueLoading()` in ExoPlayer](https://github.com/google/ExoPlayer/blob/44293e8f45fc62ff918001b4425c44d0ded5ffc9/library/core/src/main/java/com/google/android/exoplayer2/DefaultLoadControl.java#L365-L381).

I would love to see a new 1.1.x release with this change in it. I've left the default as `false` to ensure that folks who upgrade will see the same behavior unless they set `prioritizeTimeOverSize`.