### PR TITLE
[Android] Stop rogue service restarts

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -112,7 +112,7 @@ public class MusicService extends HeadlessJsTaskService {
         handler = new Handler();
 
         super.onStartCommand(intent, flags, startId);
-        return START_STICKY;
+        return START_NOT_STICKY;
     }
 
     @Override


### PR DESCRIPTION
This fixes "Module AppRegistry is not a registered callable module (calling startHeadlessTask)" crash I've been seeing in reports for a long time.

`START_STICKY` caused cases when service is started by android automatically (it was possible to reproduce it on some devices by restarting an app multiple times, while other devices never did it, so it was not easy to catch), when there is no react context yet, no MusicModule initialized, etc - and when our code tries to register playback service, app crashes with that error.