### PR TITLE
Send data with playback end event

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ios/RNTrackPlayer/Vendor/AudioPlayer"]
 	path = ios/RNTrackPlayer/Vendor/AudioPlayer
-	url = https://florianalbrecht@github.com/florianalbrecht/SwiftAudio
+	url = https://github.com/florianalbrecht/SwiftAudio.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ios/RNTrackPlayer/Vendor/AudioPlayer"]
 	path = ios/RNTrackPlayer/Vendor/AudioPlayer
-	url = https://github.com/dcvz/SwiftAudio.git
+	url = https://florianalbrecht@github.com/florianalbrecht/SwiftAudio

--- a/ios/RNTrackPlayer/Models/Track.swift
+++ b/ios/RNTrackPlayer/Models/Track.swift
@@ -10,7 +10,7 @@ import Foundation
 import MediaPlayer
 import AVFoundation
 
-class Track: NSObject, AudioItem, TimePitching, Authorizing {
+class Track: NSObject, AudioItem, TimePitching {
     let id: String
     let url: MediaURL
     

--- a/ios/RNTrackPlayer/Models/Track.swift
+++ b/ios/RNTrackPlayer/Models/Track.swift
@@ -10,7 +10,7 @@ import Foundation
 import MediaPlayer
 import AVFoundation
 
-class Track: NSObject, AudioItem, TimePitching {
+class Track: NSObject, AudioItem, TimePitching, Authorizing {
     let id: String
     let url: MediaURL
     

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -185,7 +185,7 @@ public class RNTrackPlayer: RCTEventEmitter {
         player.event.playbackEnd.addListener(self) { [weak self] (reason, currentItem, nextItem, currentTime) in
             guard let `self` = self else { return }
 
-            if reason == .playedUntilEnd && self.player.nextItems.count == 0 {
+            if reason == .playedUntilEnd && nextItem == nil {
                 self.sendEvent(withName: "playback-queue-ended", body: [
                     "track": (currentItem as? Track)?.id,
                     "position": currentTime,

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -182,19 +182,19 @@ public class RNTrackPlayer: RCTEventEmitter {
             self?.sendEvent(withName: "playback-error", body: ["error": error?.localizedDescription])
         }
         
-        player.event.playbackEnd.addListener(self) { [weak self] reason in
+        player.event.playbackEnd.addListener(self) { [weak self] (reason, currentItem, nextItem, currentTime) in
             guard let `self` = self else { return }
 
             if reason == .playedUntilEnd && self.player.nextItems.count == 0 {
                 self.sendEvent(withName: "playback-queue-ended", body: [
-                    "track": (self.player.currentItem as? Track)?.id,
-                    "position": self.player.currentTime,
+                    "track": (currentItem as? Track)?.id,
+                    "position": currentTime,
                     ])
             } else if reason == .playedUntilEnd {
                self.sendEvent(withName: "playback-track-changed", body: [
-                    "track": (self.player.currentItem as? Track)?.id,
-                    "position": self.player.currentTime,
-                    "nextTrack": (self.player.nextItems.first as? Track)?.id,
+                    "track": (currentItem as? Track)?.id,
+                    "position": currentTime,
+                    "nextTrack": (nextItem as? Track)?.id,
                     ])
             }
         }


### PR DESCRIPTION
We sometimes ran into a race condition where self.currentItem was already changed when the the playbackEnd event was handled. That's why we added it as payload to the event (see also https://github.com/dcvz/SwiftAudio/pull/6).