### PR TITLE
[android] Fix Bad notification for startForeground error

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -1,6 +1,6 @@
 package com.guichaguri.trackplayer.service;
 
-import android.app.NotificationChannel;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -15,6 +15,7 @@ import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+import com.guichaguri.trackplayer.service.Utils;
 import javax.annotation.Nullable;
 
 /**
@@ -71,11 +72,7 @@ public class MusicService extends HeadlessJsTaskService {
 
             // Checks whether there is a React activity
             if(reactContext == null || !reactContext.hasCurrentActivity()) {
-                String channel = null;
-
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    channel = NotificationChannel.DEFAULT_CHANNEL_ID;
-                }
+                String channel = Utils.getNotificationChannel((Context) this);
 
                 // Sets the service to foreground with an empty notification
                 startForeground(1, new NotificationCompat.Builder(this, channel).build());

--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -1,9 +1,12 @@
 package com.guichaguri.trackplayer.service;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Resources;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
@@ -155,5 +158,19 @@ public class Utils {
             return ((Number) value).intValue();
         }
         return defaultValue;
+    }
+
+    public static String getNotificationChannel(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                Utils.NOTIFICATION_CHANNEL,
+                "MusicService",
+                NotificationManager.IMPORTANCE_DEFAULT
+            );
+            channel.setShowBadge(false);
+            channel.setSound(null, null);
+            ((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE)).createNotificationChannel(channel);
+        }
+        return Utils.NOTIFICATION_CHANNEL;
     }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -53,16 +53,8 @@ public class MetadataManager {
         this.service = service;
         this.manager = manager;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel = new NotificationChannel(Utils.NOTIFICATION_CHANNEL, "Playback", NotificationManager.IMPORTANCE_DEFAULT);
-            channel.setShowBadge(false);
-            channel.setSound(null, null);
-
-            NotificationManager not = (NotificationManager) service.getSystemService(Context.NOTIFICATION_SERVICE);
-            not.createNotificationChannel(channel);
-        }
-
-        this.builder = new NotificationCompat.Builder(service, Utils.NOTIFICATION_CHANNEL);
+        String channel = Utils.getNotificationChannel((Context) service);
+        this.builder = new NotificationCompat.Builder(service, channel);
         this.session = new MediaSessionCompat(service, "TrackPlayer", null, null);
 
         session.setFlags(MediaSessionCompat.FLAG_HANDLES_QUEUE_COMMANDS);


### PR DESCRIPTION
This is updated https://github.com/react-native-kit/react-native-track-player/pull/579 fix by @puckey based on discussion there, fixes https://github.com/react-native-kit/react-native-track-player/issues/534 (or at least the crash mentioned in comment https://github.com/react-native-kit/react-native-track-player/issues/534#issuecomment-484014486 if it's not the one that issue author has encountered)