### PR TITLE
Fixed: Notification startForeground and Wifi Lock

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -9,13 +9,9 @@ import android.media.AudioAttributes;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.media.AudioManager.OnAudioFocusChangeListener;
-import android.net.wifi.WifiManager;
-import android.net.wifi.WifiManager.WifiLock;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.PowerManager;
-import android.os.PowerManager.WakeLock;
 import androidx.annotation.RequiresApi;
 import android.util.Log;
 import com.google.android.exoplayer2.C;
@@ -40,9 +36,6 @@ public class MusicManager implements OnAudioFocusChangeListener {
 
     private final MusicService service;
 
-    private final WakeLock wakeLock;
-    private final WifiLock wifiLock;
-
     private MetadataManager metadata;
     private ExoPlayback playback;
 
@@ -62,19 +55,9 @@ public class MusicManager implements OnAudioFocusChangeListener {
     private boolean stopWithApp = false;
     private boolean alwaysPauseOnInterruption = false;
 
-    @SuppressLint("InvalidWakeLockTag")
     public MusicManager(MusicService service) {
         this.service = service;
         this.metadata = new MetadataManager(service, this);
-
-        PowerManager powerManager = (PowerManager)service.getSystemService(Context.POWER_SERVICE);
-        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "track-player-wake-lock");
-        wakeLock.setReferenceCounted(false);
-
-        // Android 7: Use the application context here to prevent any memory leaks
-        WifiManager wifiManager = (WifiManager)service.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-        wifiLock = wifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL, "track-player-wifi-lock");
-        wifiLock.setReferenceCounted(false);
     }
 
     public ExoPlayback getPlayback() {
@@ -135,7 +118,6 @@ public class MusicManager implements OnAudioFocusChangeListener {
         return new LocalPlayback(service, this, player, cacheMaxSize);
     }
 
-    @SuppressLint("WakelockTimeout")
     public void onPlay() {
         Log.d(Utils.LOG, "onPlay");
         if(playback == null) return;
@@ -151,11 +133,8 @@ public class MusicManager implements OnAudioFocusChangeListener {
                 receivingNoisyEvents = true;
             }
 
-            if(!wakeLock.isHeld()) wakeLock.acquire();
-
-            if(!Utils.isLocal(track.uri)) {
-                if(!wifiLock.isHeld()) wifiLock.acquire();
-            }
+            // Activate the wake and the wifi locks
+            service.lockServices(Utils.isLocal(track.uri));
         }
 
         metadata.setActive(true);
@@ -170,10 +149,6 @@ public class MusicManager implements OnAudioFocusChangeListener {
             receivingNoisyEvents = false;
         }
 
-        // Release the wake and the wifi locks
-        if(wakeLock.isHeld()) wakeLock.release();
-        if(wifiLock.isHeld()) wifiLock.release();
-
         metadata.setActive(true);
     }
 
@@ -181,8 +156,7 @@ public class MusicManager implements OnAudioFocusChangeListener {
         Log.d(Utils.LOG, "onStop");
 
         // Release the wake and the wifi locks
-        if(wakeLock.isHeld()) wakeLock.release();
-        if(wifiLock.isHeld()) wifiLock.release();
+        service.unlockServices();
 
         abandonFocus();
 
@@ -352,7 +326,6 @@ public class MusicManager implements OnAudioFocusChangeListener {
         metadata.destroy();
 
         // Release the locks
-        if(wifiLock.isHeld()) wifiLock.release();
-        if(wakeLock.isHeld()) wakeLock.release();
+        service.unlockServices();
     }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -1,19 +1,20 @@
 package com.guichaguri.trackplayer.service;
 
-import android.app.NotificationChannel;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
+import android.os.PowerManager;
+import android.os.PowerManager.WakeLock;
+import android.net.wifi.WifiManager;
+import android.net.wifi.WifiManager.WifiLock;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import androidx.core.app.NotificationCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.media.session.MediaButtonReceiver;
-
-import android.net.wifi.WifiManager;
-import android.net.wifi.WifiManager.WifiLock;
-import android.os.PowerManager;
-import android.os.PowerManager.WakeLock;
 
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.ReactInstanceManager;

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -71,17 +71,26 @@ public class MusicService extends HeadlessJsTaskService {
 
             // Checks whether there is a React activity
             if(reactContext == null || !reactContext.hasCurrentActivity()) {
-                String channel = null;
-
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    channel = NotificationChannel.DEFAULT_CHANNEL_ID;
-                }
-
                 // Sets the service to foreground with an empty notification
-                startForeground(1, new NotificationCompat.Builder(this, channel).build());
+                startForeground(Utils.NOTIFICATION_ID, new NotificationCompat.Builder(this, Utils.NOTIFICATION_CHANNEL).setVisibility(NotificationCompat.VISIBILITY_SECRET).build());
                 // Stops the service right after
                 stopSelf();
             }
+        }
+    }
+
+    @Override
+    public void onCreate(){
+        super.onCreate();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(Utils.NOTIFICATION_CHANNEL, "Playback", NotificationManager.IMPORTANCE_DEFAULT);
+            channel.setDescription(Utils.SERVICE_NAME);
+            channel.setShowBadge(false);
+            channel.setSound(null, null);
+
+            NotificationManager not = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            not.createNotificationChannel(channel);
         }
     }
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -16,6 +16,8 @@ import com.google.android.exoplayer2.upstream.RawResourceDataSource;
  */
 public class Utils {
 
+    public static final int NOTIFICATION_ID = 87225752;
+    public static final String SERVICE_NAME = "trackplayer-playback";
     public static final String EVENT_INTENT = "com.guichaguri.trackplayer.event";
     public static final String CONNECT_INTENT = "com.guichaguri.trackplayer.connect";
     public static final String NOTIFICATION_CHANNEL = "com.guichaguri.trackplayer";

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -53,15 +53,6 @@ public class MetadataManager {
         this.service = service;
         this.manager = manager;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel = new NotificationChannel(Utils.NOTIFICATION_CHANNEL, "Playback", NotificationManager.IMPORTANCE_DEFAULT);
-            channel.setShowBadge(false);
-            channel.setSound(null, null);
-
-            NotificationManager not = (NotificationManager) service.getSystemService(Context.NOTIFICATION_SERVICE);
-            not.createNotificationChannel(channel);
-        }
-
         this.builder = new NotificationCompat.Builder(service, Utils.NOTIFICATION_CHANNEL);
         this.session = new MediaSessionCompat(service, "TrackPlayer", null, null);
 
@@ -79,7 +70,7 @@ public class MetadataManager {
         openApp.setAction(Intent.ACTION_VIEW);
         openApp.setData(Uri.parse("trackplayer://notification.click"));
 
-        builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, PendingIntent.FLAG_CANCEL_CURRENT));
+        builder.setContentIntent(PendingIntent.getActivity(context, Utils.NOTIFICATION_ID, openApp, PendingIntent.FLAG_CANCEL_CURRENT));
 
         builder.setSmallIcon(R.drawable.play);
         builder.setCategory(NotificationCompat.CATEGORY_TRANSPORT);
@@ -299,7 +290,7 @@ public class MetadataManager {
 
     private void updateNotification() {
         if(session.isActive()) {
-            service.startForeground(1, builder.build());
+            service.startForeground(Utils.NOTIFICATION_ID, builder.build());
         } else {
             service.stopForeground(true);
         }


### PR DESCRIPTION
This update fixes the issue already cited in [#473-Comment](https://github.com/react-native-kit/react-native-track-player/issues/473#issuecomment-507167261), #534  and partially fixes issue #711.

It also replaces Pull: #579 (@minhtc) and #723 (@biomancer and @puckey).


-------
This problem I've been trying to fix for a long time, from Friday to Monday was successful in a Samsung where formerly was disconnecting from Wi-Fi.

Problem #711 can still happen due to some Stop error, which I'm also having, which kills the player and takes a long time to play again.

Note: If you still have a background issue, the issue may be in the notification, as the 'startForeground' command is called again, instead of updating the current notification, I don't know if this is true, but I'm still studying this possibility.

