### PR TITLE
Fixed misnamed export typo in Documentation.md

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -321,10 +321,10 @@ Gets the state of the player.
 
 ## Events
 
-All event types are made available through the named export `TrackPlayerEventTypes`:
+All event types are made available through the named export `TrackPlayerEvents`:
 
 ```js
-import { TrackPlayerEventTypes } from 'react-native-track-player';
+import { TrackPlayerEvents } from 'react-native-track-player';
 ```
 
 ### Media Controls


### PR DESCRIPTION
Under "Events" in the "Documentation" secttion of the docs, the export to view all event types was incorrectly labeled as `TrackPlayerEventTypes`

Changed documentation to match correct name of `TrackPlayerEvents`. See: https://github.com/react-native-kit/react-native-track-player/blob/97692c6894c5ffaae9ad5772c4db0e24c420ac0d/lib/index.js#L202-L203