### PR TITLE
Fix: Bad notification for startForeground

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -1,6 +1,8 @@
 package com.guichaguri.trackplayer.service;
 
 import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -24,6 +26,19 @@ public class MusicService extends HeadlessJsTaskService {
 
     MusicManager manager;
     Handler handler;
+
+    @Override
+    public void onCreate(){
+        super.onCreate();
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+            NotificationChannel channel = new NotificationChannel(Utils.NOTIFICATION_CHANNEL,"MusicService",
+                    NotificationManager.IMPORTANCE_LOW);
+            channel.setShowBadge(false);
+            channel.setSound(null, null);
+            ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE)).createNotificationChannel(channel);
+        }
+    }
 
     @Nullable
     @Override
@@ -74,7 +89,7 @@ public class MusicService extends HeadlessJsTaskService {
                 String channel = null;
 
                 if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    channel = NotificationChannel.DEFAULT_CHANNEL_ID;
+                    channel = Utils.NOTIFICATION_CHANNEL;
                 }
 
                 // Sets the service to foreground with an empty notification


### PR DESCRIPTION
improved from https://github.com/react-native-kit/react-native-track-player/pull/579

Fix bug:
Fatal Exception: android.app.RemoteServiceException
Bad notification for startForeground: java.lang.RuntimeException: invalid channel for service notification: null

The default "Miscellaneous" notification channel (NotificationChannel.DEFAULT_CHANNEL_ID) doesn't exist on some devices
