### PR TITLE
Call `playback-track-changed` for last track

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -185,7 +185,7 @@ public class RNTrackPlayer: RCTEventEmitter {
         player.event.playbackEnd.addListener(self) { [weak self] reason in
             guard let `self` = self else { return }
 
-            if (reason == .playedUntilEnd) {
+            if reason == .playedUntilEnd {
                 // playbackEnd is called twice at the end of a track;
                 // we ignore .skippedToNext and only fire an event
                 // for .playedUntilEnd
@@ -194,14 +194,15 @@ public class RNTrackPlayer: RCTEventEmitter {
                     "position": self.player.currentTime,
                     "nextTrack": (self.player.nextItems.first as? Track)?.id,
                     ])
+                
+                if self.player.nextItems.count == 0 {
+                    self.sendEvent(withName: "playback-queue-ended", body: [
+                        "track": (self.player.currentItem as? Track)?.id,
+                        "position": self.player.currentTime,
+                        ])
+                }
             }
 
-            if reason == .playedUntilEnd && self.player.nextItems.count == 0 {
-                self.sendEvent(withName: "playback-queue-ended", body: [
-                    "track": (self.player.currentItem as? Track)?.id,
-                    "position": self.player.currentTime,
-                    ])
-            }
         }
         
         player.remoteCommandController.handleChangePlaybackPositionCommand = { [weak self] event in

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -185,16 +185,16 @@ public class RNTrackPlayer: RCTEventEmitter {
         player.event.playbackEnd.addListener(self) { [weak self] reason in
             guard let `self` = self else { return }
 
+            self.sendEvent(withName: "playback-track-changed", body: [
+                "track": (self.player.currentItem as? Track)?.id,
+                "position": self.player.currentTime,
+                "nextTrack": (self.player.nextItems.first as? Track)?.id,
+                ])
+
             if reason == .playedUntilEnd && self.player.nextItems.count == 0 {
                 self.sendEvent(withName: "playback-queue-ended", body: [
                     "track": (self.player.currentItem as? Track)?.id,
                     "position": self.player.currentTime,
-                    ])
-            } else if reason == .playedUntilEnd {
-               self.sendEvent(withName: "playback-track-changed", body: [
-                    "track": (self.player.currentItem as? Track)?.id,
-                    "position": self.player.currentTime,
-                    "nextTrack": (self.player.nextItems.first as? Track)?.id,
                     ])
             }
         }

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -185,11 +185,16 @@ public class RNTrackPlayer: RCTEventEmitter {
         player.event.playbackEnd.addListener(self) { [weak self] reason in
             guard let `self` = self else { return }
 
-            self.sendEvent(withName: "playback-track-changed", body: [
-                "track": (self.player.currentItem as? Track)?.id,
-                "position": self.player.currentTime,
-                "nextTrack": (self.player.nextItems.first as? Track)?.id,
-                ])
+            if (reason == .playedUntilEnd) {
+                // playbackEnd is called twice at the end of a track;
+                // we ignore .skippedToNext and only fire an event
+                // for .playedUntilEnd
+                self.sendEvent(withName: "playback-track-changed", body: [
+                    "track": (self.player.currentItem as? Track)?.id,
+                    "position": self.player.currentTime,
+                    "nextTrack": (self.player.nextItems.first as? Track)?.id,
+                    ])
+            }
 
             if reason == .playedUntilEnd && self.player.nextItems.count == 0 {
                 self.sendEvent(withName: "playback-queue-ended", body: [


### PR DESCRIPTION
Fixes an issue on iOS where `playback-track-changed` isn't called when switching from the penultimate track of the queue to the last track, causing metadata not to update.

This behaves as expected on Android.

