### PR TITLE
refactor(Android): getState() directly returns STATE_NONE when service is disconnected

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -456,6 +456,10 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
 
     @ReactMethod
     public void getState(final Promise callback) {
-        waitForConnection(() -> callback.resolve(binder.getPlayback().getState()));
+        if (binder == null) {
+            callback.resolve(PlaybackStateCompat.STATE_NONE);
+        } else {
+            waitForConnection(() -> callback.resolve(binder.getPlayback().getState()));
+        }
     }
 }


### PR DESCRIPTION
`TrackPlayer.getState()` now directly returns **STATE_NONE** if there is no service running, instead of waiting for the service creation in `waitForConnection()`.