### PR TITLE
[iOS] Resolve promise for updateMetadataForTrack

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -572,5 +572,6 @@ public class RNTrackPlayer: RCTEventEmitter {
                 }
             }
         }
+        resolve(NSNull())
     }
 }


### PR DESCRIPTION
On iOS updateMetadataForTrack never called resolve, meaning TrackPlayer.updateMetadataForTrack would await forever.