### PR TITLE
[iOS - fix] Update podspecs with build errors on v1.2.2

### DIFF
--- a/react-native-track-player.podspec
+++ b/react-native-track-player.podspec
@@ -7,13 +7,14 @@ Pod::Spec.new do |s|
   s.version      = package["version"]
   s.summary      = package['description']
   s.license      = package['license']
-  
+
   s.author       = "David Chavez"
   s.homepage     = package['repository']['url']
   s.platform     = :ios, "10.0"
 
   s.source       = { :git => package['repository']['url'], :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,swift}"
+  s.exclude_files = ["ios/RNTrackPlayer/Vendor/AudioPlayer/Example"]
 
   s.dependency "React"
 end


### PR DESCRIPTION
- Update podspecs by excluding example folder

- Fixes #867 https://github.com/react-native-kit/react-native-track-player/issues/867#issuecomment-603807017
- Fixes #503 https://github.com/react-native-kit/react-native-track-player/issues/503#issuecomment-578087334
