### PR TITLE
reporting last track changed on android

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -302,7 +302,10 @@ public abstract class ExoPlayback<T extends Player> implements EventListener, Me
             previousState = state;
 
             if(state == PlaybackStateCompat.STATE_STOPPED) {
-                manager.onEnd(getCurrentTrack(), getPosition());
+                Track previous = getCurrentTrack();
+                long position = getPosition();
+                manager.onTrackUpdate(previous, position, null);
+                manager.onEnd(previous, position);
             }
         }
     }


### PR DESCRIPTION
solves #909.
Since track changed seems to be identified while the player is playing the next track, the simplest way to solve this is by reporting changed track right before reporting that the queue ended