### PR TITLE
Update hooks

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -567,14 +567,17 @@ A hook alternative to the [Progress Component](#progresscomponent).
 | bufferedPosition | `number` | The buffered position in seconds |
 | duration         | `number` | The duration in seconds          |
 
-`useTrackPlayerProgress` accepts two arguments:
+`useTrackPlayerProgress` accepts two arguments
 
-1. `interval`: An interval to set the rate (in miliseconds) to poll the track player's progress (default value is `1000` or every second)
-2. `pollTrackPlayerStates`: An optional whitelist of playback states at which the track player's progress is polled.
+| Param                 | Type      | Description                            |
+| --------------------- | --------- | -------------------------------------- |
+| interval              | `number`  | An interval to set the rate (in miliseconds) to poll the track player's progress (default value is `1000` or every second)  |
+| pollTrackPlayerStates | `State[]` | An optional whitelist of playback states at which the track player's progress is polled.  |
 
-  Provide `null` in case you want really poll at the `interval`'s rate, no matter the playback state the player is in.
+More information concerning the `pollTrackPlayerStates` argument:
 
-  By default the hook will only poll while a track is playing or buffering, i.e. the default value for the second argument is:
+- Provide `null` in case you want really poll at the `interval`'s rate, no matter the playback state the player is in.
+- By default the hook will only poll while a track is playing or buffering, i.e. the default value for the second argument is:
 
   ```js
   [

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -109,7 +109,7 @@ If the player is already initialized, the promise will resolve instantly.
 
 | Param                | Type     | Description   | Default   | Android | iOS | Windows |
 | -------------------- | -------- | ------------- | --------- | :-----: | :-: | :-----: |
-| options              | `object` | The options   | 
+| options              | `object` | The options   |
 | options.minBuffer    | `number` | Minimum time in seconds that needs to be buffered | 15 | ✓ | ✗ | ✗ |
 | options.maxBuffer    | `number` | Maximum time in seconds that needs to be buffered | 50 | ✓ | ✗ | ✗ |
 | options.playBuffer   | `number` | Minimum time in seconds that needs to be buffered to start playing | 2.5 | ✓ | ✗ | ✗ |
@@ -517,9 +517,10 @@ For more information about Resource Objects, read the [Images](https://facebook.
 
 ## React Hooks
 
-React v16.8 introduced [hooks](https://reactjs.org/docs/hooks-intro.html). If you are using a version of React Native that is before [v0.59.0](https://facebook.github.io/react-native/blog/2019/03/12/releasing-react-native-059), your React Native version does not support hooks. 
+React v16.8 introduced [hooks](https://reactjs.org/docs/hooks-intro.html). If you are using a version of React Native that is before [v0.59.0](https://facebook.github.io/react-native/blog/2019/03/12/releasing-react-native-059), your React Native version does not support hooks.
 
 #### `useTrackPlayerEvents`
+
 Register an event listener for one or more of the [events](#events) emitted by the TrackPlayer. The subscription is removed when the component unmounts.
 
 Check out the [events section](#events) for a full list of supported events.
@@ -553,11 +554,11 @@ const MyComponent = () => {
     <View>
       <Text>The TrackPlayer is {isPlaying ? 'playing' : 'not playing'}</Text>
     </View>
-  ); 
+  );
 };
 ```
 
-#### `useTrackPlayerProgress`
+#### `useTrackPlayerProgress(interval, pollTrackPlayerStates)`
 A hook alternative to the [Progress Component](#progresscomponent).
 
 | State            | Type     | Description                      |
@@ -566,7 +567,22 @@ A hook alternative to the [Progress Component](#progresscomponent).
 | bufferedPosition | `number` | The buffered position in seconds |
 | duration         | `number` | The duration in seconds          |
 
-`useTrackPlayerProgress` accepts an interval to set the rate (in miliseconds) to poll the track player's progress. The default value is `1000` or every second.
+`useTrackPlayerProgress` accepts two arguments:
+
+1. `interval`: An interval to set the rate (in miliseconds) to poll the track player's progress (default value is `1000` or every second)
+2. `pollTrackPlayerStates`: An optional whitelist of playback states at which the track player's progress is polled.
+
+  Provide `null` in case you want really poll at the `interval`'s rate, no matter the playback state the player is in.
+
+  By default the hook will only poll while a track is playing or buffering, i.e. the default value for the second argument is:
+
+  ```js
+  [
+    TrackPlayer.STATE_PLAYING,
+    TrackPlayer.STATE_BUFFERING,
+  ]
+  ```
+
 
 ```jsx
 import React from 'react';
@@ -574,7 +590,7 @@ import { Text, View } from 'react-native';
 import { useTrackPlayerProgress } from 'react-native-track-player';
 
 const MyComponent = () => {
-  const { position, bufferedPosition, duration } = useTrackPlayerProgress()
+  const { position, bufferedPosition, duration } = useTrackPlayerProgress(1000, null)
 
   return (
     <View>

--- a/index.d.ts
+++ b/index.d.ts
@@ -230,10 +230,15 @@ declare namespace RNTrackPlayer {
 
   // Hooks
   export function usePlaybackState(): State;
-  export function useTrackPlayerEvents(events: string[], handler: (event: any) => void): void;
-  export function useInterval(callback: ()=> void, delay: number): void;
-  export function useWhenPlaybackStateChanges(callback: ()=> void): void;
-  export function usePlaybackStateIs(...states: string[]): boolean;
-  export function useTrackPlayerProgress(interval?: number): ProgressComponentState;
-
+  export function useTrackPlayerEvents(
+    events: string[],
+    handler: (event: any) => void
+  ): void;
+  export function useInterval(callback: () => void, delay: number): void;
+  export function useWhenPlaybackStateChanges(callback: () => void): void;
+  export function usePlaybackStateIs(...states: State[]): boolean;
+  export function useTrackPlayerProgress(
+    interval?: number,
+    pollTrackPlayerStates?: State[],
+  ): ProgressComponentState;
 }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -131,35 +131,35 @@ const usePlaybackStateIs = (...states) => {
 const useTrackPlayerProgress = (
     interval = 1000,
     pollTrackPlayerStates = [
-      TrackPlayer.STATE_PLAYING,
-      TrackPlayer.STATE_BUFFERING,
+        TrackPlayer.STATE_PLAYING,
+        TrackPlayer.STATE_BUFFERING,
     ]
-  ) => {
+) => {
     const initialState = {
-      position: 0,
-      bufferedPosition: 0,
-      duration: 0,
+        position: 0,
+        bufferedPosition: 0,
+        duration: 0,
     };
 
     const [state, setState] = useState(initialState);
 
     const getProgress = async () => {
-      const [position, bufferedPosition, duration] = await Promise.all([
-        TrackPlayer.getPosition(),
-        TrackPlayer.getBufferedPosition(),
-        TrackPlayer.getDuration(),
-      ]);
-      setState({ position, bufferedPosition, duration });
+        const [position, bufferedPosition, duration] = await Promise.all([
+            TrackPlayer.getPosition(),
+            TrackPlayer.getBufferedPosition(),
+            TrackPlayer.getDuration(),
+        ]);
+        setState({ position, bufferedPosition, duration });
     };
 
     let needsPoll = true;
     if (pollTrackPlayerStates) {
-      needsPoll = usePlaybackStateIs(...pollTrackPlayerStates);
+        needsPoll = usePlaybackStateIs(...pollTrackPlayerStates);
     }
 
     useInterval(getProgress, needsPoll ? interval : null);
     return state;
-  };
+};
 
 
 // Exports

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -16,7 +16,7 @@ const usePlaybackState = () => {
         }
 
         setPlayerState()
-        
+
         const sub = TrackPlayer.addEventListener(TrackPlayer.TrackPlayerEvents.PLAYBACK_STATE, data => {
             setState(data.state)
         })
@@ -118,6 +118,7 @@ const usePlaybackStateIs = (...states) => {
  * @description
  *   Poll for track progress for the given interval (in miliseconds)
  * @param {number} interval - ms interval
+ * @param {Array<TrackPlayerState> | null} pollTrackPlayerStates - TrackPlayer states on which the track progress should be polled. If null is provided, the track progress will be polled every `interval` seconds.
  * @returns {[
  *   {
  *      progress: number,
@@ -127,31 +128,38 @@ const usePlaybackStateIs = (...states) => {
  *   (interval: number) => void
  * ]}
  */
-const useTrackPlayerProgress = (interval = 1000) => {
+const useTrackPlayerProgress = (
+    interval = 1000,
+    pollTrackPlayerStates = [
+      TrackPlayer.STATE_PLAYING,
+      TrackPlayer.STATE_BUFFERING,
+    ]
+  ) => {
     const initialState = {
-        position: 0,
-        bufferedPosition: 0,
-        duration: 0
+      position: 0,
+      bufferedPosition: 0,
+      duration: 0,
     };
 
     const [state, setState] = useState(initialState);
 
     const getProgress = async () => {
-        const [position, bufferedPosition, duration] = await Promise.all([
-            TrackPlayer.getPosition(),
-            TrackPlayer.getBufferedPosition(),
-            TrackPlayer.getDuration()
-        ])
-        setState({ position, bufferedPosition, duration });
+      const [position, bufferedPosition, duration] = await Promise.all([
+        TrackPlayer.getPosition(),
+        TrackPlayer.getBufferedPosition(),
+        TrackPlayer.getDuration(),
+      ]);
+      setState({ position, bufferedPosition, duration });
+    };
+
+    let needsPoll = true;
+    if (pollTrackPlayerStates) {
+      needsPoll = usePlaybackStateIs(...pollTrackPlayerStates);
     }
 
-    const needsPoll = usePlaybackStateIs(
-        TrackPlayer.STATE_PLAYING,
-        TrackPlayer.STATE_BUFFERING
-    );
     useInterval(getProgress, needsPoll ? interval : null);
     return state;
-}
+  };
 
 
 // Exports

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -165,4 +165,7 @@ const useTrackPlayerProgress = (
 // Exports
 module.exports.usePlaybackState = usePlaybackState
 module.exports.useTrackPlayerEvents = useTrackPlayerEvents
+module.exports.useInterval = useInterval
+module.exports.useWhenPlaybackStateChanges = useWhenPlaybackStateChanges
+module.exports.usePlaybackStateIs = usePlaybackStateIs
 module.exports.useTrackPlayerProgress = useTrackPlayerProgress


### PR DESCRIPTION
This PR does two things:

1. Gives the possibility to the `useTrackPlayerProgress` hook to return the correct Player `position` even if it is currently not buffering or playing. The signature of the hook was changed such that it still has the former behavior as a default value. This way it works exactly the same for people how already use it and just adds the possibility to use the hook when e.g. creating a movable Slider.

2. Expose the hooks which are already documented in the Typescript typings file but not yet exposed.