### PR TITLE
[iOS] Resolve some issues with provided url formatting.

### DIFF
--- a/ios/RNTrackPlayer/Models/MediaURL.swift
+++ b/ios/RNTrackPlayer/Models/MediaURL.swift
@@ -25,7 +25,24 @@ struct MediaURL {
         } else {
             let url = object as! String
             isLocal = url.lowercased().hasPrefix("file://")
-            value = URL(string: url.replacingOccurrences(of: "file://", with: ""))!
+            if isLocal {
+                // When the provided url is local,
+                // remove the file:// prefix,
+                // and attempt to remove any existing encoding.
+                // Both of these can both cause URL(fileURLWithPath: string) to fail
+                var path = url.replacingOccurrences(of: "file://", with: "")
+                path = path.removingPercentEncoding ?? path
+                value = URL(fileURLWithPath: path)
+            } else {
+                // When the provided url is not local, attempt to use it without any modifications
+                if let urlValue = URL(string: url) {
+                    value = urlValue
+                } else {
+                    // If url could not be initialized, try encoding it
+                    print("Warning: The provided url could not be parsed. Attempting to encode url instead.")
+                    value = URL(string: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)!
+                }
+            }
         }
     }
 }

--- a/ios/RNTrackPlayer/Models/MediaURL.swift
+++ b/ios/RNTrackPlayer/Models/MediaURL.swift
@@ -26,7 +26,7 @@ struct MediaURL {
                 url = String(format: "%@.bundle/%@", bundleName, url)
             }
             
-            isLocal = url.lowercased().contains("http") ? false : true
+            isLocal = url.lowercased().hasPrefix("http") ? false : true
             value = RCTConvert.nsurl(url)
         } else {
             let url = object as! String

--- a/ios/RNTrackPlayer/Models/Track.swift
+++ b/ios/RNTrackPlayer/Models/Track.swift
@@ -79,7 +79,7 @@ class Track: NSObject, AudioItem, TimePitching, AssetOptionsProviding {
     // MARK: - AudioItem Protocol
     
     func getSourceUrl() -> String {
-        return url.value.absoluteString
+        return url.isLocal ? url.value.path : url.value.absoluteString
     }
     
     func getArtist() -> String? {


### PR DESCRIPTION
Without these changes the following provided urls were failing on iOS:

```js
url: encodeURI(`file://${RNFS.MainBundlePath}/assets/foo bar.mp3`), // fails to play
url: `file://${RNFS.MainBundlePath}/assets/foo bar.mp3`, // crash on add
url: `file://${RNFS.MainBundlePath}/assets/foo[bar].mp3`, // fails to play
url: require("./assets/foo bar.mp3"), // fails to play
```

With these changes, all of the above work.

(except the last one using `require` with spaces, which still fails in debug mode, but works in release. I feel this is a metro issue)

I am looking for some input on whether this should be changed. I have seen some old discussions about letting the developer handle encoding and such. This change would apply encoding as a last resort.

Here are some related issues:

https://github.com/react-native-kit/react-native-track-player/issues/947 (spaces)
https://github.com/react-native-kit/react-native-track-player/pull/71 (old discussion about taking encoding out)
https://github.com/react-native-kit/react-native-track-player/issues/44 (encoding)
https://github.com/react-native-kit/react-native-track-player/issues/874
https://github.com/react-native-kit/react-native-track-player/issues/794#issuecomment-573353727
https://github.com/react-native-kit/react-native-track-player/issues/794#issuecomment-619060395
https://github.com/react-native-kit/react-native-track-player/issues/167 (spaces, crashing)

---

## Tested with the following values for url

```
require(`./assets/test/foo-bar.mp3`)
require(`./assets/test/foo bar.mp3`) // fails in debug, works in release
require(`./assets/test/foo[bar.mp3`)
require(`./assets/test/fooæbar.mp3`)

file://${RNFS.MainBundlePath}/assets/test/foo-bar.mp3
file://${RNFS.MainBundlePath}/assets/test/foo bar.mp3
file://${RNFS.MainBundlePath}/assets/test/foo[bar.mp3
file://${RNFS.MainBundlePath}/assets/test/fooæbar.mp3
file://${RNFS.MainBundlePath}/assets/test/foo%C3%A6bar.mp3
file://${RNFS.MainBundlePath}/assets/test/foo%C3%A6baræ.mp3 // fails in both debug and release

https://test.domain.com/public/pin/test/foo-bar.mp3
https://test.domain.com/public/pin/test/foo bar.mp3
https://test.domain.com/public/pin/test/foo[bar.mp3
https://test.domain.com/public/pin/test/fooæbar.mp3
https://test.domain.com/public/pin/test/foo%C3%A6bar.mp3
https://test.domain.com/public/pin/test/foo%C3%A6baræ.mp3 // fails in both debug and release

// Test Issue #617
https://firebasestorage.googleapis.com/v0/b/hupper-mobile.appspot.com/o/audio_meditation%2Fanxiety%2FTeste_Raffael%20Marfara%CC%81_20%20segundos.mp3?alt=media&token=55aff5c0-1af7-4a8b-b4a2-f450c12f181c

```
