### PR TITLE
[ios] fix race conditions (close #652)

### DIFF
--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/NowPlayingInfoController/NowPlayingInfoController.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/NowPlayingInfoController/NowPlayingInfoController.swift
@@ -8,43 +8,49 @@
 import Foundation
 import MediaPlayer
 
-
 public class NowPlayingInfoController: NowPlayingInfoControllerProtocol {
-    
+
     private var _infoCenter: NowPlayingInfoCenter
     private var _info: [String: Any] = [:]
-    
+
     var infoCenter: NowPlayingInfoCenter {
         return _infoCenter
     }
-    
+
     var info: [String: Any] {
         return _info
     }
-    
+
+
+
     public required init() {
         self._infoCenter = MPNowPlayingInfoCenter.default()
     }
-    
+
     public required init(infoCenter: NowPlayingInfoCenter) {
         self._infoCenter = infoCenter
     }
-    
+
     public func set(keyValues: [NowPlayingInfoKeyValue]) {
-        keyValues.forEach { (keyValue) in
-            _info[keyValue.getKey()] = keyValue.getValue()
+        DispatchQueue.main.async {
+            keyValues.forEach { (keyValue) in
+                self._info[keyValue.getKey()] = keyValue.getValue()
+            }
+            self._infoCenter.nowPlayingInfo = self._info
         }
-        self._infoCenter.nowPlayingInfo = _info
     }
-    
+
     public func set(keyValue: NowPlayingInfoKeyValue) {
-        _info[keyValue.getKey()] = keyValue.getValue()
-        self._infoCenter.nowPlayingInfo = _info
+        DispatchQueue.main.async {
+            self._info[keyValue.getKey()] = keyValue.getValue()
+            self._infoCenter.nowPlayingInfo = self._info
+        }
     }
-    
+
     public func clear() {
-        self._info = [:]
-        self._infoCenter.nowPlayingInfo = _info
+        DispatchQueue.main.async {
+            self._info = [:]
+            self._infoCenter.nowPlayingInfo = self._info
+        }
     }
-    
 }

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/NowPlayingInfoController/NowPlayingInfoController.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/NowPlayingInfoController/NowPlayingInfoController.swift
@@ -21,8 +21,6 @@ public class NowPlayingInfoController: NowPlayingInfoControllerProtocol {
         return _info
     }
 
-
-
     public required init() {
         self._infoCenter = MPNowPlayingInfoCenter.default()
     }


### PR DESCRIPTION
I was experiencing a bunch of crashes in production with 1.2.3

There was already a solution proposed here: https://github.com/react-native-kit/react-native-track-player/issues/652

I was able to reproduce the issue locally and used Thread Ripper to test the [solution](https://github.com/react-native-kit/react-native-track-player/issues/652#issuecomment-587426577) proposed in the above issue.