### PR TITLE
[ios] deduce togglePlayPause from play and pause capabilities

### DIFF
--- a/ios/RNTrackPlayer/Models/Capabilities.swift
+++ b/ios/RNTrackPlayer/Models/Capabilities.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum Capability: String {
-    case play, pause, stop, next, previous, jumpForward, jumpBackward, seek, like, dislike, bookmark
+    case play, pause, togglePlayPause, stop, next, previous, jumpForward, jumpBackward, seek, like, dislike, bookmark
     
     func mapToPlayerCommand(jumpInterval: NSNumber?,
                             likeOptions: [String: Any]?,
@@ -22,6 +22,8 @@ enum Capability: String {
             return .play
         case .pause:
             return .pause
+        case .togglePlayPause:
+            return .togglePlayPause
         case .next:
             return .next
         case .previous:

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -264,8 +264,13 @@ public class RNTrackPlayer: RCTEventEmitter {
     
     @objc(updateOptions:resolver:rejecter:)
     public func update(options: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        let capabilitiesStr = options["capabilities"] as? [String]
-        let capabilities = capabilitiesStr?.compactMap { Capability(rawValue: $0) } ?? []
+
+        var capabilitiesStr = options["capabilities"] as? [String] ?? []
+        if (capabilitiesStr.contains("play") && capabilitiesStr.contains("pause")) {
+            capabilitiesStr = capabilitiesStr.filter { $0 != "play" && $0 != "pause" }
+            capabilitiesStr.append("togglePlayPause");
+        }
+        let capabilities = capabilitiesStr.compactMap { Capability(rawValue: $0) }
         
         let remoteCommands = capabilities.map { capability in
             capability.mapToPlayerCommand(jumpInterval: options["jumpInterval"] as? NSNumber,

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -267,7 +267,6 @@ public class RNTrackPlayer: RCTEventEmitter {
 
         var capabilitiesStr = options["capabilities"] as? [String] ?? []
         if (capabilitiesStr.contains("play") && capabilitiesStr.contains("pause")) {
-            capabilitiesStr = capabilitiesStr.filter { $0 != "play" && $0 != "pause" }
             capabilitiesStr.append("togglePlayPause");
         }
         let capabilities = capabilitiesStr.compactMap { Capability(rawValue: $0) }


### PR DESCRIPTION
This adds support for toggling playback for headphones. Started at https://github.com/react-native-kit/react-native-track-player/pull/531, but deducing togglePlayPause from play and pause capabilities instead of adding it as a separate one. Tested using wired apple headphones.