### PR TITLE
[ios] resync playback values when updating NowPlayingInfoCenter

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -496,13 +496,14 @@ public class RNTrackPlayer: RCTEventEmitter {
                 MediaItemProperty.title(track.title),
                 MediaItemProperty.albumTitle(track.album),
             ])
-            
+            player.updateNowPlayingPlaybackValues();
             track.getArtwork { [weak self] image in
                 if let image = image {
                     let artwork = MPMediaItemArtwork(boundsSize: image.size, requestHandler: { (size) -> UIImage in
                         return image
                     })
                     self?.player.nowPlayingInfoController.set(keyValue: MediaItemProperty.artwork(artwork))
+                    self?.player.updateNowPlayingPlaybackValues();
                 }
             }
         }


### PR DESCRIPTION
As [reported](https://github.com/react-native-kit/react-native-track-player/pull/941#issuecomment-634273879) by @ds8k, the elapsed time in the ios lockscreen is reset to zero when calling `TrackPlayer.updateMetadataForTrack`. 

Looking at Apple's NowPlayable demo code, I found that they update the elapsed playback time whenever they update anything in the NowPlayingInfoCenter:

```swift
    func setNowPlayingPlaybackInfo(_ metadata: NowPlayableDynamicMetadata) {
        
        let nowPlayingInfoCenter = MPNowPlayingInfoCenter.default()
        var nowPlayingInfo = nowPlayingInfoCenter.nowPlayingInfo ?? [String: Any]()
        
        NSLog("%@", "**** Set playback info: rate \(metadata.rate), position \(metadata.position), duration \(metadata.duration)")
        nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = metadata.duration
        nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = metadata.position
        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = metadata.rate
        nowPlayingInfo[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
        nowPlayingInfo[MPNowPlayingInfoPropertyCurrentLanguageOptions] = metadata.currentLanguageOptions
        nowPlayingInfo[MPNowPlayingInfoPropertyAvailableLanguageOptions] = metadata.availableLanguageOptionGroups
        
        nowPlayingInfoCenter.nowPlayingInfo = nowPlayingInfo
    }
```

This PR does the same by calling `player.updateNowPlayingPlaybackValues()` after `player.nowPlayingInfoController.set` is called.

@ds8k would you like to give this PR a go?