### PR TITLE
Fixed broken links in ReadMe Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ All audio modules (like `react-native-sound`) don't play in a separated service 
 
 ## First Steps
 
-If you want to get started with this module, check the [Getting Started](./API.md) page.
-If you want detailed information about the API, check the [Documentation](./Documentation.md). You can also look at our example project [here](https://github.com/react-native-kit/react-native-track-player/tree/dev/example).
+If you want to get started with this module, check the [Getting Started](https://react-native-track-player.js.org/getting-started/) page.
+If you want detailed information about the API, check the [Documentation](https://react-native-track-player.js.org/documentation/). You can also look at our example project [here](https://github.com/react-native-kit/react-native-track-player/tree/dev/example).
 
 ## Example
 


### PR DESCRIPTION
Links to Get Started and API documentation were pointing directly to markdown files which were unavailable

I have replaced these links to their respective documentation [](https://react-native-track-player.js.org)