### PR TITLE
Fixes "Use of unresolved identifier 'RCTConvert' error"

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayerBridge.h
+++ b/ios/RNTrackPlayer/RNTrackPlayerBridge.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "RCTConvert.h"
 
 @interface RNTrackPlayerBridge: NSObject
 @end


### PR DESCRIPTION
This error was introduced by [the newest dev branch commit](https://github.com/react-native-kit/react-native-track-player/commit/5efe26cd5b46c1c91c18ffaa09fe12dc7299e3ea) and after running `pod install`.

To fix the error

```
Use of unresolved identifier 'RCTConvert'
```

I added the line `#import "RCTConvert.h"` into [RNTrackPlayerBridge.h](https://github.com/react-native-kit/react-native-track-player/blob/a89f8ba97a2462c137ccd126af9ec40962a82bb5/ios/RNTrackPlayer/RNTrackPlayerBridge.h).

Perhaps this is not the best solution since the other RCT headers (as [outlined here](https://stackoverflow.com/questions/40081012/react-native-app-purely-in-swift#answer-40084879)) are not imported in [RNTrackPlayerBridge.h](https://github.com/react-native-kit/react-native-track-player/blob/a89f8ba97a2462c137ccd126af9ec40962a82bb5/ios/RNTrackPlayer/RNTrackPlayerBridge.h).

Feel free to move/remove the header import to adhere with the style of development. I'm not very experienced in Swift development.