### PR TITLE
[iOS] Add AirPlay 2 Support

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -170,8 +170,15 @@ public class RNTrackPlayer: RCTEventEmitter {
                 sessionCategoryMode = mappedCategoryMode.mapConfigToAVAudioSessionCategoryMode()
         }
         
-        try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, options: sessionCategoryOptions)
-        
+        // Progressively opt into AVAudioSession policies for background audio
+        // and AirPlay 2. 
+        if #available(iOS 13.0, *) {
+            try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, policy: .longFormAudio, options: sessionCategoryOptions)
+        } else if #available(iOS 11.0, *) {
+            try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, policy: .longForm, options: sessionCategoryOptions)
+        } else {
+            try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, options: sessionCategoryOptions)
+        }
         
         // setup event listeners
         player.remoteCommandController.handleChangePlaybackPositionCommand = { [weak self] event in

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -59,6 +59,10 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         self.playerTimeObserver.delegate = self
         self.playerItemNotificationObserver.delegate = self
         self.playerItemObserver.delegate = self
+
+        // Disable external video output, so we can get the audio controls when
+        // using AirPlay.
+        self.avPlayer.allowsExternalPlayback = false;
         
         playerTimeObserver.registerForPeriodicTimeEvents()
     }


### PR DESCRIPTION
Hi there guys,

I was using react-native-track-player, and found its Airplay support was already mostly there! Yet, I ran into two hiccups:
1. When setting AirPlay output, the audio volume is disabled on the device
2. The Apple TV to which I output shows it as if it's a video stream, with metadata missing

I consulted the internet, and these two problems seem relatively simple to fix (see [here](https://stackoverflow.com/questions/12221787/how-to-keep-the-slider-of-mpvolumeview-visible-when-connecting-to-apple-tv/14743134) for instance), by setting `allowsExternalPlayback` to false on `AVPlayer`. This (counter-intuitively) sets the AirPlay stream to audio, rather than video, opening up volume controls and settings the proper metadata when streaming to the Apple TV.

Additionally, I made an effort to [set up AirPlay 2](https://developer.apple.com/documentation/avfoundation/airplay_2/getting_airplay_2_into_your_app) properly for this application. Fortunately, most of the work is already done, with the docs only recommending to set a RouteSharingPolicy, which I have implemented. Unfortunately, I have no means if AirPlay 2 is actually working, but I these settings do no harm regardless.

This pull request at the very least improves QOL for those who wish to use react-native-track-player in combination with AirPlay, and I would recommend it be merged. 

I am here for any additional questions.

Cheers,
Lei