### PR TITLE
Fix(progress): progress reflects previous track

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -80,6 +80,7 @@ const useInterval = (callback, delay) => {
 
     useEffect(() => {
         if (!delay) return;
+        savedCallback.current();
         const id = setInterval(savedCallback.current, delay);
         return () => clearInterval(id);
     }, [delay]);


### PR DESCRIPTION
When `needsPoll` is `true` based on a new PLAYER_STATE, you'd expect to have the progress **directly** and then after each `interval`.
This adds the **directly**