### PR TITLE
Add tip about `waitForBuffer`  for network media

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,10 @@ TrackPlayer.setupPlayer().then(() => {
     // The player is ready to be used
 });
 ```
+_Note:_ On iOS if you notice that network media immediately pauses after it buffers, you may need to setup the player with the `waitForBuffer` option:
+```javascript
+TrackPlayer.setupPlayer({waitForBuffer:true})
+```
 
 You also need to register a [playback service](#playback-service) right after registering the main component of your app:
 ```javascript


### PR DESCRIPTION
I ran into the issue where the audio would pause immediately after buffering a stream and would require a second `play()` call to start playing.  After searching the issues found that a lot of people #601 #594 #616 #978.  While there is some discussion if this should be enabled by default or perhaps there is a deep issue. However, until it is resolve, (for some of us at least) this seems to fix the issue and making a note in a docs would be handy.